### PR TITLE
SF-001 — Bootstrap Python project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Python 3.12 validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project and development dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e '.[dev]'
+
+      - name: Ruff
+        run: ruff check .
+
+      - name: Mypy
+        run: mypy signalforge
+
+      - name: Pytest
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[project]
+name = "signalforge"
+version = "0.0.0"
+description = "Strategy-driven intraday trading research, backtesting, paper-trading and execution framework for NSE equities."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+  "pydantic>=2.8,<3",
+]
+
+[project.optional-dependencies]
+dev = [
+  "mypy>=1.11,<2",
+  "pytest>=8.3,<9",
+  "pytest-cov>=5,<7",
+  "ruff>=0.6,<1",
+]
+
+[tool.pytest.ini_options]
+addopts = "-ra --strict-config --strict-markers"
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["signalforge"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_unused_configs = true
+packages = ["signalforge"]

--- a/signalforge/__init__.py
+++ b/signalforge/__init__.py
@@ -1,0 +1,3 @@
+"""SignalForge trading research and execution framework."""
+
+__version__ = "0.0.0"

--- a/signalforge/config/__init__.py
+++ b/signalforge/config/__init__.py
@@ -1,0 +1,1 @@
+"""Typed SignalForge configuration and run identity models."""

--- a/signalforge/domain/__init__.py
+++ b/signalforge/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Core broker-independent SignalForge domain models."""

--- a/tests/unit/test_package_imports.py
+++ b/tests/unit/test_package_imports.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+import signalforge
+
+
+def test_package_imports() -> None:
+    assert signalforge.__version__ == "0.0.0"


### PR DESCRIPTION
## What changed
Bootstraps the minimal Python 3.12+ project foundation for SignalForge M0.

- Adds `pyproject.toml`
- Configures Hatchling build metadata
- Adds Pydantic v2 runtime dependency
- Adds pytest, pytest-cov, Ruff and mypy development tooling
- Creates minimal `signalforge`, `domain`, and `config` package skeleton
- Creates unit/integration test skeleton
- Adds a basic package import/version test

## Why
SF-001 requires a deterministic, testable project foundation before domain implementation begins.

## Validation
- GitHub diff reviewed: one commit, six new files, branch is based directly on current `develop`.
- Local pytest/Ruff/mypy execution could not be performed from the ChatGPT runtime because normal network access to clone the GitHub repository is unavailable.
- SF-001 should remain open until these commands are run locally or CI is added and passing.

Suggested local validation:
```bash
python -m pip install -e '.[dev]'
pytest
ruff check .
mypy signalforge
```

## Architecture impact
Implements M0 project foundation only. No strategy semantic changes.

Relates to #2.