### PR TITLE
SF-002 — Add deterministic IDs and provenance

### DIFF
--- a/signalforge/domain/ids.py
+++ b/signalforge/domain/ids.py
@@ -65,7 +65,7 @@ class InstrumentId(_IdBase):
     pass
 
 
-def deterministic_id[_IdT: _IdBase](id_type: type[_IdT], *parts: str) -> _IdT:
+def deterministic_id[IdT: _IdBase](id_type: type[IdT], *parts: str) -> IdT:
     """Create a stable identifier from explicit logical identity components.
 
     The identifier type participates in the hash domain so identical parts used

--- a/signalforge/domain/ids.py
+++ b/signalforge/domain/ids.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import TypeVar
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,10 +65,7 @@ class InstrumentId(_IdBase):
     pass
 
 
-_IdT = TypeVar("_IdT", bound=_IdBase)
-
-
-def deterministic_id(id_type: type[_IdT], *parts: str) -> _IdT:
+def deterministic_id[_IdT: _IdBase](id_type: type[_IdT], *parts: str) -> _IdT:
     """Create a stable identifier from explicit logical identity components.
 
     The identifier type participates in the hash domain so identical parts used

--- a/signalforge/domain/ids.py
+++ b/signalforge/domain/ids.py
@@ -1,0 +1,86 @@
+"""Strongly typed identifiers for SignalForge domain entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import TypeVar
+
+
+@dataclass(frozen=True, slots=True)
+class _IdBase:
+    """Immutable string-backed identifier with non-empty validation."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not self.value or not self.value.strip():
+            raise ValueError(f"{type(self).__name__} must not be empty")
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass(frozen=True, slots=True)
+class RunId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class SignalId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class TriggerEventId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class FillId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class TradeId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class PositionId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ExitId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentId(_IdBase):
+    pass
+
+
+_IdT = TypeVar("_IdT", bound=_IdBase)
+
+
+def deterministic_id(id_type: type[_IdT], *parts: str) -> _IdT:
+    """Create a stable identifier from explicit logical identity components.
+
+    The identifier type participates in the hash domain so identical parts used
+    for different entity types cannot collide by construction.
+    """
+
+    if not parts:
+        raise ValueError("deterministic_id requires at least one identity component")
+    if any(not part or not part.strip() for part in parts):
+        raise ValueError("deterministic_id components must not be empty")
+
+    payload = "\x1f".join((id_type.__name__, *parts)).encode("utf-8")
+    digest = sha256(payload).hexdigest()
+    return id_type(digest)

--- a/signalforge/domain/provenance.py
+++ b/signalforge/domain/provenance.py
@@ -1,0 +1,34 @@
+"""Immutable strategy and run provenance models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from signalforge.domain.ids import ConfigId, RunId
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyIdentity:
+    strategy_id: str
+    strategy_version: str
+
+    def __post_init__(self) -> None:
+        if not self.strategy_id or not self.strategy_id.strip():
+            raise ValueError("strategy_id must not be empty")
+        if not self.strategy_version or not self.strategy_version.strip():
+            raise ValueError("strategy_version must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class RunIdentity:
+    run_id: RunId
+    strategy: StrategyIdentity
+    config_id: ConfigId
+    config_hash: str
+    engine_calculation_version: str
+
+    def __post_init__(self) -> None:
+        if not self.config_hash or not self.config_hash.strip():
+            raise ValueError("config_hash must not be empty")
+        if not self.engine_calculation_version or not self.engine_calculation_version.strip():
+            raise ValueError("engine_calculation_version must not be empty")

--- a/tests/unit/domain/test_ids.py
+++ b/tests/unit/domain/test_ids.py
@@ -1,0 +1,92 @@
+"""Tests for SignalForge typed identifiers."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from signalforge.domain.ids import (
+    ConfigId,
+    ExitId,
+    FillId,
+    InstrumentId,
+    PositionId,
+    RunId,
+    SignalId,
+    TradeId,
+    TriggerEventId,
+    deterministic_id,
+)
+
+
+def test_ids_reject_empty_values() -> None:
+    with pytest.raises(ValueError):
+        RunId("")
+
+    with pytest.raises(ValueError):
+        ConfigId("   ")
+
+
+def test_ids_are_immutable() -> None:
+    signal_id = SignalId("abc")
+
+    with pytest.raises(FrozenInstanceError):
+        signal_id.value = "def"  # type: ignore[misc]
+
+
+def test_deterministic_id_is_stable_for_same_inputs() -> None:
+    first = deterministic_id(
+        SignalId,
+        "strategy",
+        "1.0.0",
+        "config",
+        "instrument",
+        "2026-08-30T09:20",
+    )
+    second = deterministic_id(
+        SignalId,
+        "strategy",
+        "1.0.0",
+        "config",
+        "instrument",
+        "2026-08-30T09:20",
+    )
+
+    assert first == second
+
+
+def test_deterministic_id_changes_when_material_input_changes() -> None:
+    base = deterministic_id(SignalId, "strategy", "1.0.0", "config-a", "instrument", "candle")
+    changed = deterministic_id(SignalId, "strategy", "1.0.0", "config-b", "instrument", "candle")
+
+    assert base != changed
+
+
+def test_deterministic_id_is_namespaced_by_id_type() -> None:
+    signal = deterministic_id(SignalId, "same", "parts")
+    trade = deterministic_id(TradeId, "same", "parts")
+
+    assert signal.value != trade.value
+
+
+def test_deterministic_id_rejects_missing_or_blank_components() -> None:
+    with pytest.raises(ValueError):
+        deterministic_id(SignalId)
+
+    with pytest.raises(ValueError):
+        deterministic_id(SignalId, "valid", " ")
+
+
+def test_all_initial_id_types_can_be_constructed() -> None:
+    id_types = (
+        RunId,
+        ConfigId,
+        SignalId,
+        TriggerEventId,
+        FillId,
+        TradeId,
+        PositionId,
+        ExitId,
+        InstrumentId,
+    )
+
+    assert all(str(id_type("value")) == "value" for id_type in id_types)

--- a/tests/unit/domain/test_provenance.py
+++ b/tests/unit/domain/test_provenance.py
@@ -1,0 +1,67 @@
+"""Tests for immutable SignalForge provenance models."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from signalforge.domain.ids import ConfigId, RunId
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+
+
+def test_strategy_identity_rejects_blank_fields() -> None:
+    with pytest.raises(ValueError):
+        StrategyIdentity(strategy_id="", strategy_version="1.0.0")
+
+    with pytest.raises(ValueError):
+        StrategyIdentity(strategy_id="intraday_momentum_v1", strategy_version=" ")
+
+
+def test_run_identity_is_immutable() -> None:
+    identity = RunIdentity(
+        run_id=RunId("run-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("baseline"),
+        config_hash="a" * 64,
+        engine_calculation_version="calc-v1",
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        identity.config_hash = "b" * 64  # type: ignore[misc]
+
+
+def test_run_identity_rejects_blank_provenance_fields() -> None:
+    strategy = StrategyIdentity("intraday_momentum_v1", "1.0.0")
+
+    with pytest.raises(ValueError):
+        RunIdentity(
+            run_id=RunId("run-001"),
+            strategy=strategy,
+            config_id=ConfigId("baseline"),
+            config_hash=" ",
+            engine_calculation_version="calc-v1",
+        )
+
+    with pytest.raises(ValueError):
+        RunIdentity(
+            run_id=RunId("run-001"),
+            strategy=strategy,
+            config_id=ConfigId("baseline"),
+            config_hash="a" * 64,
+            engine_calculation_version=" ",
+        )
+
+
+def test_run_identity_preserves_exact_provenance() -> None:
+    identity = RunIdentity(
+        run_id=RunId("run-20260830-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-baseline"),
+        config_hash="0123456789abcdef" * 4,
+        engine_calculation_version="indicator-spec-v1",
+    )
+
+    assert identity.strategy.strategy_id == "intraday_momentum_v1"
+    assert identity.strategy.strategy_version == "1.0.0"
+    assert identity.config_id == ConfigId("config-baseline")
+    assert identity.config_hash == "0123456789abcdef" * 4
+    assert identity.engine_calculation_version == "indicator-spec-v1"


### PR DESCRIPTION
## What changed
Implements the SF-002 identity and provenance foundation.

- Adds strongly typed immutable IDs for Run, Config, Signal, TriggerEvent, Fill, Trade, Position, Exit, and Instrument
- Adds deterministic logical ID generation using SHA-256 over explicit identity components
- Namespaces deterministic hashes by ID type
- Adds immutable StrategyIdentity and RunIdentity provenance models
- Adds unit tests for stability, material-input changes, immutability, invalid values, and provenance preservation

## Why
SignalForge requires reproducible logical identity and immutable run provenance before later domain entities and persistence can be implemented safely.

## Scope boundary
Config hash *generation/canonicalization* is intentionally not implemented here; that remains SF-007. SF-002 only carries an already-derived config hash as immutable provenance.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002 identity/provenance requirements. No strategy semantic changes.

Relates to #3.