### PR TITLE
SF-003 — Add timezone-safe time primitives

### DIFF
--- a/signalforge/domain/time.py
+++ b/signalforge/domain/time.py
@@ -1,0 +1,56 @@
+"""Timezone-safe primitives for SignalForge market and candle timestamps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def require_aware(value: datetime) -> datetime:
+    """Return *value* if timezone-aware; reject naive datetimes."""
+
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("datetime must be timezone-aware")
+    return value
+
+
+def to_utc(value: datetime) -> datetime:
+    """Convert an aware datetime to UTC without changing the instant."""
+
+    return require_aware(value).astimezone(UTC)
+
+
+def to_ist(value: datetime) -> datetime:
+    """Convert an aware datetime to Asia/Kolkata without changing the instant."""
+
+    return require_aware(value).astimezone(IST)
+
+
+@dataclass(frozen=True, slots=True)
+class CandleInterval:
+    """Half-open candle interval ``[start, end)``."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        require_aware(self.start)
+        require_aware(self.end)
+        if self.end <= self.start:
+            raise ValueError("CandleInterval end must be after start")
+
+    @classmethod
+    def five_minutes(cls, start: datetime) -> CandleInterval:
+        """Build a deterministic five-minute interval from an aware start."""
+
+        start = require_aware(start)
+        return cls(start=start, end=start + timedelta(minutes=5))
+
+    def contains(self, value: datetime) -> bool:
+        """Return whether *value* belongs to this half-open interval."""
+
+        value = require_aware(value)
+        return self.start <= value < self.end

--- a/tests/unit/domain/test_time.py
+++ b/tests/unit/domain/test_time.py
@@ -3,7 +3,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from signalforge.domain.time import CandleInterval, IST, require_aware, to_ist, to_utc
+from signalforge.domain.time import IST, CandleInterval, require_aware, to_ist, to_utc
 
 
 def test_require_aware_rejects_naive_datetime() -> None:

--- a/tests/unit/domain/test_time.py
+++ b/tests/unit/domain/test_time.py
@@ -1,0 +1,82 @@
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.time import CandleInterval, IST, require_aware, to_ist, to_utc
+
+
+def test_require_aware_rejects_naive_datetime() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        require_aware(datetime(2026, 8, 30, 9, 15))
+
+
+def test_timezone_conversion_preserves_instant() -> None:
+    ist_value = datetime(2026, 8, 30, 9, 15, tzinfo=IST)
+    utc_value = to_utc(ist_value)
+
+    assert utc_value == datetime(2026, 8, 30, 3, 45, tzinfo=UTC)
+    assert to_ist(utc_value) == ist_value
+
+
+def test_ist_constant_uses_exchange_timezone() -> None:
+    assert IST.key == "Asia/Kolkata"
+
+
+def test_candle_interval_requires_aware_timestamps() -> None:
+    aware = datetime(2026, 8, 30, 9, 15, tzinfo=IST)
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        CandleInterval(start=datetime(2026, 8, 30, 9, 15), end=aware)
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        CandleInterval(start=aware, end=datetime(2026, 8, 30, 9, 20))
+
+
+def test_candle_interval_requires_positive_duration() -> None:
+    start = datetime(2026, 8, 30, 9, 15, tzinfo=IST)
+
+    with pytest.raises(ValueError, match="after start"):
+        CandleInterval(start=start, end=start)
+
+    with pytest.raises(ValueError, match="after start"):
+        CandleInterval(start=start, end=start - timedelta(minutes=5))
+
+
+def test_five_minute_interval_is_deterministic() -> None:
+    start = datetime(2026, 8, 30, 9, 15, tzinfo=IST)
+
+    interval = CandleInterval.five_minutes(start)
+
+    assert interval.start == start
+    assert interval.end == datetime(2026, 8, 30, 9, 20, tzinfo=IST)
+
+
+def test_candle_interval_is_half_open() -> None:
+    interval = CandleInterval.five_minutes(datetime(2026, 8, 30, 9, 15, tzinfo=IST))
+
+    assert interval.contains(datetime(2026, 8, 30, 9, 15, tzinfo=IST))
+    assert interval.contains(datetime(2026, 8, 30, 9, 19, 59, 999999, tzinfo=IST))
+    assert not interval.contains(datetime(2026, 8, 30, 9, 20, tzinfo=IST))
+
+
+def test_interval_membership_compares_same_instant_across_timezones() -> None:
+    interval = CandleInterval.five_minutes(datetime(2026, 8, 30, 9, 15, tzinfo=IST))
+
+    assert interval.contains(datetime(2026, 8, 30, 3, 47, tzinfo=UTC))
+    assert not interval.contains(datetime(2026, 8, 30, 3, 50, tzinfo=UTC))
+
+
+def test_candle_interval_is_immutable() -> None:
+    interval = CandleInterval.five_minutes(datetime(2026, 8, 30, 9, 15, tzinfo=IST))
+
+    with pytest.raises(AttributeError):
+        interval.start = datetime(2026, 8, 30, 9, 20, tzinfo=IST)  # type: ignore[misc]
+
+
+def test_conversion_accepts_non_ist_aware_timezone() -> None:
+    london = ZoneInfo("Europe/London")
+    value = datetime(2026, 8, 30, 9, 15, tzinfo=london)
+
+    assert to_utc(value).tzinfo is UTC
+    assert to_ist(value).tzinfo == IST


### PR DESCRIPTION
## What changed
Implements the SF-003 time foundation.

- Rejects naive datetimes at the domain boundary
- Defines explicit `Asia/Kolkata` exchange timezone support
- Adds UTC and IST conversion helpers that preserve the instant
- Adds immutable half-open `CandleInterval [start, end)`
- Adds deterministic five-minute interval construction
- Adds unit tests for timezone conversion, interval boundaries, immutability, and aware-datetime validation

## Why
SignalForge relies on exchange timestamps and deterministic candle boundaries. Time semantics must therefore be explicit and timezone-safe before candle construction and market-event processing are implemented.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002/ADR-005 time semantics. No strategy semantic changes.

Relates to #4.