### PR TITLE
SF-004 — Add Decimal price and quantity primitives

### DIFF
--- a/signalforge/domain/money.py
+++ b/signalforge/domain/money.py
@@ -1,0 +1,38 @@
+"""Decimal-safe monetary and quantity primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class Price:
+    """Immutable finite Decimal-backed price value."""
+
+    value: Decimal
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, Decimal):
+            raise TypeError("Price value must be a Decimal")
+        if not self.value.is_finite():
+            raise ValueError("Price value must be finite")
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+@dataclass(frozen=True, slots=True)
+class Quantity:
+    """Immutable strictly positive integral quantity."""
+
+    value: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.value, bool) or not isinstance(self.value, int):
+            raise TypeError("Quantity value must be an integer")
+        if self.value <= 0:
+            raise ValueError("Quantity value must be strictly positive")
+
+    def __int__(self) -> int:
+        return self.value

--- a/tests/unit/domain/test_money.py
+++ b/tests/unit/domain/test_money.py
@@ -1,0 +1,58 @@
+from dataclasses import FrozenInstanceError
+from decimal import Decimal
+
+import pytest
+
+from signalforge.domain.money import Price, Quantity
+
+
+def test_price_requires_decimal() -> None:
+    with pytest.raises(TypeError, match="Decimal"):
+        Price(100.25)  # type: ignore[arg-type]
+
+
+def test_price_rejects_non_finite_decimal() -> None:
+    for value in (Decimal("NaN"), Decimal("Infinity"), Decimal("-Infinity")):
+        with pytest.raises(ValueError, match="finite"):
+            Price(value)
+
+
+def test_price_preserves_decimal_exactness() -> None:
+    first = Price(Decimal("0.1"))
+    second = Price(Decimal("0.2"))
+
+    assert first.value + second.value == Decimal("0.3")
+    assert str(Price(Decimal("123.4500"))) == "123.4500"
+
+
+def test_price_is_immutable() -> None:
+    price = Price(Decimal("100.00"))
+
+    with pytest.raises(FrozenInstanceError):
+        price.value = Decimal("101.00")  # type: ignore[misc]
+
+
+def test_quantity_accepts_positive_integer() -> None:
+    quantity = Quantity(25)
+
+    assert quantity.value == 25
+    assert int(quantity) == 25
+
+
+@pytest.mark.parametrize("value", [0, -1, -100])
+def test_quantity_rejects_non_positive_values(value: int) -> None:
+    with pytest.raises(ValueError, match="strictly positive"):
+        Quantity(value)
+
+
+@pytest.mark.parametrize("value", [True, False, 1.5, Decimal("2")])
+def test_quantity_rejects_non_integer_values(value: object) -> None:
+    with pytest.raises(TypeError, match="integer"):
+        Quantity(value)  # type: ignore[arg-type]
+
+
+def test_quantity_is_immutable() -> None:
+    quantity = Quantity(5)
+
+    with pytest.raises(FrozenInstanceError):
+        quantity.value = 6  # type: ignore[misc]


### PR DESCRIPTION
## What changed
Implements SF-004 numeric primitives.

- Adds immutable `Price` backed strictly by finite `Decimal`
- Rejects float/non-Decimal price construction
- Adds immutable `Quantity` backed by strictly positive integers
- Rejects booleans and non-integer quantity values
- Adds unit tests for exact Decimal arithmetic, invalid values, and immutability

## Why
SignalForge must avoid binary floating-point drift in price/tick arithmetic and must enforce deterministic quantity semantics before instrument tick rules and price normalization are implemented.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements M0 numeric primitives. No strategy semantic changes.

Relates to #5.