### PR TITLE
SF-005 — Add effective-dated instrument tick rules

### DIFF
--- a/signalforge/domain/instruments.py
+++ b/signalforge/domain/instruments.py
@@ -1,0 +1,73 @@
+"""Broker-neutral instrument metadata and effective-dated tick-size rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.money import Price
+
+
+@dataclass(frozen=True, slots=True)
+class Instrument:
+    """Broker-independent identity and market symbol metadata."""
+
+    instrument_id: InstrumentId
+    exchange: str
+    symbol: str
+
+    def __post_init__(self) -> None:
+        if not self.exchange or not self.exchange.strip():
+            raise ValueError("Instrument exchange must not be empty")
+        if not self.symbol or not self.symbol.strip():
+            raise ValueError("Instrument symbol must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class TickSizeRule:
+    """Tick size effective for an inclusive trading-date range."""
+
+    tick_size: Price
+    effective_from: date
+    effective_to: date | None = None
+
+    def __post_init__(self) -> None:
+        if self.tick_size.value <= 0:
+            raise ValueError("Tick size must be strictly positive")
+        if self.effective_to is not None and self.effective_to < self.effective_from:
+            raise ValueError("Tick-size effective_to must not precede effective_from")
+
+    def applies_on(self, trading_date: date) -> bool:
+        """Return whether this rule applies on *trading_date*."""
+
+        if trading_date < self.effective_from:
+            return False
+        return self.effective_to is None or trading_date <= self.effective_to
+
+
+@dataclass(frozen=True, slots=True)
+class TickSizeSchedule:
+    """Deterministic effective-dated tick rules for one instrument."""
+
+    instrument_id: InstrumentId
+    rules: tuple[TickSizeRule, ...]
+
+    def __post_init__(self) -> None:
+        if not self.rules:
+            raise ValueError("TickSizeSchedule requires at least one rule")
+
+        ordered = tuple(sorted(self.rules, key=lambda rule: rule.effective_from))
+        for previous, current in zip(ordered, ordered[1:], strict=False):
+            if previous.effective_to is None or current.effective_from <= previous.effective_to:
+                raise ValueError("Tick-size rules must not overlap")
+
+        object.__setattr__(self, "rules", ordered)
+
+    def tick_size_on(self, trading_date: date) -> Price:
+        """Resolve the tick size applicable on *trading_date*."""
+
+        for rule in self.rules:
+            if rule.applies_on(trading_date):
+                return rule.tick_size
+        raise LookupError(f"No tick-size rule for {self.instrument_id} on {trading_date.isoformat()}")

--- a/signalforge/domain/instruments.py
+++ b/signalforge/domain/instruments.py
@@ -70,4 +70,6 @@ class TickSizeSchedule:
         for rule in self.rules:
             if rule.applies_on(trading_date):
                 return rule.tick_size
-        raise LookupError(f"No tick-size rule for {self.instrument_id} on {trading_date.isoformat()}")
+        raise LookupError(
+            f"No tick-size rule for {self.instrument_id} on {trading_date.isoformat()}"
+        )

--- a/tests/unit/domain/test_instruments.py
+++ b/tests/unit/domain/test_instruments.py
@@ -1,0 +1,112 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.instruments import Instrument, TickSizeRule, TickSizeSchedule
+from signalforge.domain.money import Price
+
+
+def _price(value: str) -> Price:
+    return Price(Decimal(value))
+
+
+def test_instrument_metadata_is_broker_independent() -> None:
+    instrument = Instrument(
+        instrument_id=InstrumentId("nse-equity-reliance"),
+        exchange="NSE",
+        symbol="RELIANCE",
+    )
+
+    assert instrument.exchange == "NSE"
+    assert instrument.symbol == "RELIANCE"
+    assert not hasattr(instrument, "broker_id")
+    assert not hasattr(instrument, "token")
+
+
+def test_instrument_rejects_empty_exchange_or_symbol() -> None:
+    with pytest.raises(ValueError, match="exchange"):
+        Instrument(InstrumentId("x"), " ", "RELIANCE")
+
+    with pytest.raises(ValueError, match="symbol"):
+        Instrument(InstrumentId("x"), "NSE", " ")
+
+
+def test_tick_size_rule_rejects_non_positive_tick_size() -> None:
+    with pytest.raises(ValueError, match="strictly positive"):
+        TickSizeRule(_price("0"), date(2026, 1, 1))
+
+    with pytest.raises(ValueError, match="strictly positive"):
+        TickSizeRule(_price("-0.05"), date(2026, 1, 1))
+
+
+def test_tick_size_rule_rejects_reversed_effective_dates() -> None:
+    with pytest.raises(ValueError, match="effective_to"):
+        TickSizeRule(_price("0.05"), date(2026, 2, 1), date(2026, 1, 31))
+
+
+def test_tick_size_rule_dates_are_inclusive() -> None:
+    rule = TickSizeRule(_price("0.05"), date(2026, 1, 1), date(2026, 1, 31))
+
+    assert rule.applies_on(date(2026, 1, 1))
+    assert rule.applies_on(date(2026, 1, 31))
+    assert not rule.applies_on(date(2025, 12, 31))
+    assert not rule.applies_on(date(2026, 2, 1))
+
+
+def test_schedule_resolves_historical_tick_size() -> None:
+    schedule = TickSizeSchedule(
+        instrument_id=InstrumentId("nse-equity-example"),
+        rules=(
+            TickSizeRule(_price("0.10"), date(2026, 7, 1)),
+            TickSizeRule(_price("0.05"), date(2025, 1, 1), date(2026, 6, 30)),
+        ),
+    )
+
+    assert schedule.tick_size_on(date(2026, 6, 30)) == _price("0.05")
+    assert schedule.tick_size_on(date(2026, 7, 1)) == _price("0.10")
+    assert schedule.rules[0].effective_from == date(2025, 1, 1)
+
+
+def test_schedule_rejects_overlapping_rules() -> None:
+    with pytest.raises(ValueError, match="must not overlap"):
+        TickSizeSchedule(
+            instrument_id=InstrumentId("nse-equity-example"),
+            rules=(
+                TickSizeRule(_price("0.05"), date(2026, 1, 1), date(2026, 6, 30)),
+                TickSizeRule(_price("0.10"), date(2026, 6, 30), date(2026, 12, 31)),
+            ),
+        )
+
+
+def test_open_ended_rule_must_be_last_chronologically() -> None:
+    with pytest.raises(ValueError, match="must not overlap"):
+        TickSizeSchedule(
+            instrument_id=InstrumentId("nse-equity-example"),
+            rules=(
+                TickSizeRule(_price("0.05"), date(2026, 1, 1)),
+                TickSizeRule(_price("0.10"), date(2026, 7, 1)),
+            ),
+        )
+
+
+def test_schedule_raises_when_no_rule_applies() -> None:
+    schedule = TickSizeSchedule(
+        instrument_id=InstrumentId("nse-equity-example"),
+        rules=(TickSizeRule(_price("0.05"), date(2026, 1, 1)),),
+    )
+
+    with pytest.raises(LookupError, match="No tick-size rule"):
+        schedule.tick_size_on(date(2025, 12, 31))
+
+
+def test_tick_rule_and_schedule_are_immutable() -> None:
+    rule = TickSizeRule(_price("0.05"), date(2026, 1, 1))
+    schedule = TickSizeSchedule(InstrumentId("nse-equity-example"), (rule,))
+
+    with pytest.raises(AttributeError):
+        rule.effective_to = date(2026, 12, 31)  # type: ignore[misc]
+
+    with pytest.raises(AttributeError):
+        schedule.rules = ()  # type: ignore[misc]


### PR DESCRIPTION
## What changed
Implements SF-005 instrument reference and tick-size rules.

- Adds broker-neutral `Instrument` metadata with `InstrumentId`, exchange, and symbol
- Adds immutable `TickSizeRule` with inclusive effective-date ranges
- Adds open-ended tick rules via `effective_to=None`
- Adds deterministic `TickSizeSchedule` historical lookup by trading date
- Rejects non-positive tick sizes, reversed date ranges, overlapping rules, and empty schedules
- Adds unit tests for historical resolution, boundary dates, overlap rejection, broker independence, and immutability

## Why
SignalForge must resolve the authoritative tick size applicable to a security on a specific historical trading date without coupling the core domain to broker-specific identifiers.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-001/ADR-004 instrument reference boundary. No strategy semantic changes.

Relates to #6.