### PR TITLE
SF-006 — Add tick-aware price normalization

### DIFF
--- a/signalforge/domain/money.py
+++ b/signalforge/domain/money.py
@@ -1,9 +1,9 @@
-"""Decimal-safe monetary and quantity primitives."""
+"""Decimal-safe monetary, quantity, and price-normalization primitives."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import ROUND_CEILING, Decimal
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,3 +36,13 @@ class Quantity:
 
     def __int__(self) -> int:
         return self.value
+
+
+def ceil_to_tick(price: Price, tick_size: Price) -> Price:
+    """Return the smallest valid tick-aligned price greater than or equal to *price*."""
+
+    if tick_size.value <= 0:
+        raise ValueError("Tick size must be strictly positive")
+
+    ticks = (price.value / tick_size.value).to_integral_value(rounding=ROUND_CEILING)
+    return Price(ticks * tick_size.value)

--- a/tests/unit/domain/test_price_normalization.py
+++ b/tests/unit/domain/test_price_normalization.py
@@ -1,0 +1,53 @@
+from decimal import Decimal
+
+import pytest
+
+from signalforge.domain.money import Price, ceil_to_tick
+
+
+def test_tick_aligned_price_is_unchanged() -> None:
+    price = Price(Decimal("100.10"))
+    tick = Price(Decimal("0.05"))
+
+    assert ceil_to_tick(price, tick) == price
+
+
+def test_between_tick_price_rounds_up() -> None:
+    price = Price(Decimal("100.11"))
+    tick = Price(Decimal("0.05"))
+
+    assert ceil_to_tick(price, tick) == Price(Decimal("100.15"))
+
+
+def test_awkward_decimal_tick_is_deterministic() -> None:
+    price = Price(Decimal("1.0000001"))
+    tick = Price(Decimal("0.0000003"))
+
+    assert ceil_to_tick(price, tick) == Price(Decimal("1.0000002"))
+
+
+def test_non_power_of_ten_tick_is_supported() -> None:
+    price = Price(Decimal("99.991"))
+    tick = Price(Decimal("0.025"))
+
+    assert ceil_to_tick(price, tick) == Price(Decimal("100.000"))
+
+
+def test_tick_size_must_be_positive() -> None:
+    price = Price(Decimal("100"))
+
+    with pytest.raises(ValueError, match="strictly positive"):
+        ceil_to_tick(price, Price(Decimal("0")))
+
+    with pytest.raises(ValueError, match="strictly positive"):
+        ceil_to_tick(price, Price(Decimal("-0.05")))
+
+
+def test_ceiling_never_returns_below_input() -> None:
+    price = Price(Decimal("123.4567"))
+    tick = Price(Decimal("0.07"))
+
+    normalized = ceil_to_tick(price, tick)
+
+    assert normalized.value >= price.value
+    assert normalized.value % tick.value == 0


### PR DESCRIPTION
## What changed
Implements SF-006 price normalization.

- Adds reusable `ceil_to_tick(price, tick_size)` helper
- Uses exact `Decimal` arithmetic with `ROUND_CEILING`
- Preserves already tick-aligned prices unchanged
- Rounds between-tick prices upward to the next valid tick
- Rejects non-positive tick sizes
- Adds tests for awkward decimals and non-power-of-ten tick sizes

## Why
SignalForge Strategy V1 requires tradable entry triggers and targets to be normalized upward to the next valid exchange tick without binary floating-point drift or decimal-place heuristics.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements Strategy V1 tradable-trigger/target translation. No strategy semantic changes.

Relates to #7.