### PR TITLE
SF-007 — Add canonical config hashing

### DIFF
--- a/signalforge/config/identity.py
+++ b/signalforge/config/identity.py
@@ -45,7 +45,6 @@ def canonical_config_json(config: Mapping[str, object]) -> str:
     normalized = _normalize_value(config)
     return json.dumps(
         normalized,
-        sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,
         allow_nan=False,
@@ -71,29 +70,38 @@ def identify_config(
 
 
 def _normalize_value(value: object) -> object:
-    if value is None or isinstance(value, (bool, int, str)):
-        return value
+    """Convert supported values to an unambiguous type-tagged canonical structure."""
+
+    if value is None:
+        return ["null"]
+    if isinstance(value, bool):
+        return ["bool", value]
+    if isinstance(value, int):
+        return ["int", str(value)]
+    if isinstance(value, str):
+        return ["str", value]
 
     if isinstance(value, Decimal):
         if not value.is_finite():
             raise ValueError("Configuration Decimal values must be finite")
-        return {"$decimal": _canonical_decimal(value)}
+        return ["decimal", _canonical_decimal(value)]
 
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError("Configuration float values must be finite")
-        return {"$decimal": _canonical_decimal(Decimal(str(value)))}
+        return ["decimal", _canonical_decimal(Decimal(str(value)))]
 
     if isinstance(value, Mapping):
-        normalized: dict[str, object] = {}
+        items: list[list[object]] = []
         for key, item in value.items():
             if not isinstance(key, str):
                 raise TypeError("Configuration mapping keys must be strings")
-            normalized[key] = _normalize_value(item)
-        return normalized
+            items.append([key, _normalize_value(item)])
+        items.sort(key=lambda item: item[0])
+        return ["map", items]
 
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return [_normalize_value(item) for item in value]
+        return ["list", [_normalize_value(item) for item in value]]
 
     raise TypeError(f"Unsupported configuration value type: {type(value).__name__}")
 

--- a/signalforge/config/identity.py
+++ b/signalforge/config/identity.py
@@ -1,0 +1,105 @@
+"""Canonical SignalForge configuration identity and hashing."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import StrEnum
+from hashlib import sha256
+
+from signalforge.domain.ids import ConfigId
+
+
+class ConfigStatus(StrEnum):
+    """Lifecycle states currently supported by SignalForge configuration governance."""
+
+    EXPERIMENTAL = "experimental"
+    ACCEPTED = "accepted"
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigIdentity:
+    """Immutable identity and governance status for one normalized configuration."""
+
+    config_id: ConfigId
+    config_hash: str
+    status: ConfigStatus
+
+    def __post_init__(self) -> None:
+        if self.config_id.value != self.config_hash:
+            raise ValueError("Config ID must equal the canonical config hash")
+        if len(self.config_hash) != 64:
+            raise ValueError("Config hash must be a SHA-256 hex digest")
+        try:
+            int(self.config_hash, 16)
+        except ValueError as exc:
+            raise ValueError("Config hash must be a SHA-256 hex digest") from exc
+
+
+def canonical_config_json(config: Mapping[str, object]) -> str:
+    """Serialize normalized configuration data into deterministic canonical JSON."""
+
+    normalized = _normalize_value(config)
+    return json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def config_hash(config: Mapping[str, object]) -> str:
+    """Return the SHA-256 digest of the canonical configuration representation."""
+
+    canonical = canonical_config_json(config).encode("utf-8")
+    return sha256(canonical).hexdigest()
+
+
+def identify_config(
+    config: Mapping[str, object],
+    *,
+    status: ConfigStatus = ConfigStatus.EXPERIMENTAL,
+) -> ConfigIdentity:
+    """Build immutable config identity from normalized semantic content."""
+
+    digest = config_hash(config)
+    return ConfigIdentity(config_id=ConfigId(digest), config_hash=digest, status=status)
+
+
+def _normalize_value(value: object) -> object:
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise ValueError("Configuration Decimal values must be finite")
+        return {"$decimal": _canonical_decimal(value)}
+
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Configuration float values must be finite")
+        return {"$decimal": _canonical_decimal(Decimal(str(value)))}
+
+    if isinstance(value, Mapping):
+        normalized: dict[str, object] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("Configuration mapping keys must be strings")
+            normalized[key] = _normalize_value(item)
+        return normalized
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_normalize_value(item) for item in value]
+
+    raise TypeError(f"Unsupported configuration value type: {type(value).__name__}")
+
+
+def _canonical_decimal(value: Decimal) -> str:
+    normalized = value.normalize()
+    if normalized == 0:
+        return "0"
+    return format(normalized, "f")

--- a/signalforge/config/identity.py
+++ b/signalforge/config/identity.py
@@ -92,13 +92,13 @@ def _normalize_value(value: object) -> object:
         return ["decimal", _canonical_decimal(Decimal(str(value)))]
 
     if isinstance(value, Mapping):
-        items: list[list[object]] = []
+        items: list[tuple[str, object]] = []
         for key, item in value.items():
             if not isinstance(key, str):
                 raise TypeError("Configuration mapping keys must be strings")
-            items.append([key, _normalize_value(item)])
+            items.append((key, _normalize_value(item)))
         items.sort(key=lambda item: item[0])
-        return ["map", items]
+        return ["map", [[key, item] for key, item in items]]
 
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return ["list", [_normalize_value(item) for item in value]]

--- a/tests/unit/config/test_identity.py
+++ b/tests/unit/config/test_identity.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from decimal import Decimal
+
+import pytest
+
+from signalforge.config.identity import (
+    ConfigIdentity,
+    ConfigStatus,
+    canonical_config_json,
+    config_hash,
+    identify_config,
+)
+from signalforge.domain.ids import ConfigId
+
+
+def test_semantically_identical_key_order_hashes_identically() -> None:
+    left = {
+        "strategy": "intraday_momentum_v1",
+        "parameters": {"rsi_max": 65, "rsi_min": 58, "entry_offset": 0.001},
+    }
+    right = {
+        "parameters": {"entry_offset": 0.001, "rsi_min": 58, "rsi_max": 65},
+        "strategy": "intraday_momentum_v1",
+    }
+
+    assert canonical_config_json(left) == canonical_config_json(right)
+    assert config_hash(left) == config_hash(right)
+
+
+def test_equivalent_decimal_formatting_hashes_identically() -> None:
+    left = {"entry_offset": Decimal("0.0010")}
+    right = {"entry_offset": Decimal("0.001")}
+
+    assert config_hash(left) == config_hash(right)
+
+
+def test_float_and_equivalent_decimal_normalize_identically() -> None:
+    left = {"reward_risk": 1.5}
+    right = {"reward_risk": Decimal("1.50")}
+
+    assert config_hash(left) == config_hash(right)
+
+
+def test_material_parameter_change_changes_hash() -> None:
+    baseline = {"adx_min": 22, "reward_risk": 1.5}
+    changed = {"adx_min": 23, "reward_risk": 1.5}
+
+    assert config_hash(baseline) != config_hash(changed)
+
+
+def test_sequence_order_is_semantic() -> None:
+    first = {"periods": [9, 20, 50]}
+    second = {"periods": [50, 20, 9]}
+
+    assert config_hash(first) != config_hash(second)
+
+
+def test_identify_config_uses_hash_as_config_id() -> None:
+    config = {"strategy": "intraday_momentum_v1", "version": "1.0.0"}
+
+    identity = identify_config(config, status=ConfigStatus.ACCEPTED)
+
+    assert identity.config_id.value == identity.config_hash
+    assert identity.config_hash == config_hash(config)
+    assert identity.status is ConfigStatus.ACCEPTED
+
+
+def test_identify_config_defaults_to_experimental() -> None:
+    identity = identify_config({"strategy": "candidate"})
+
+    assert identity.status is ConfigStatus.EXPERIMENTAL
+
+
+def test_config_identity_rejects_mismatched_id_and_hash() -> None:
+    digest = "a" * 64
+
+    with pytest.raises(ValueError, match="Config ID must equal"):
+        ConfigIdentity(
+            config_id=ConfigId("b" * 64),
+            config_hash=digest,
+            status=ConfigStatus.EXPERIMENTAL,
+        )
+
+
+def test_config_identity_is_immutable() -> None:
+    identity = identify_config({"strategy": "candidate"})
+
+    with pytest.raises(FrozenInstanceError):
+        identity.status = ConfigStatus.ACCEPTED  # type: ignore[misc]
+
+
+def test_non_string_mapping_key_is_rejected() -> None:
+    with pytest.raises(TypeError, match="mapping keys must be strings"):
+        config_hash({"parameters": {1: "invalid"}})  # type: ignore[dict-item]
+
+
+def test_non_finite_numeric_values_are_rejected() -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        config_hash({"threshold": float("nan")})
+
+    with pytest.raises(ValueError, match="must be finite"):
+        config_hash({"threshold": Decimal("Infinity")})
+
+
+def test_unsupported_values_are_rejected() -> None:
+    with pytest.raises(TypeError, match="Unsupported configuration value type"):
+        config_hash({"symbols": {"RELIANCE", "TCS"}})

--- a/tests/unit/config/test_identity.py
+++ b/tests/unit/config/test_identity.py
@@ -43,6 +43,13 @@ def test_float_and_equivalent_decimal_normalize_identically() -> None:
     assert config_hash(left) == config_hash(right)
 
 
+def test_internal_type_tags_cannot_collide_with_user_mapping_data() -> None:
+    numeric = {"threshold": Decimal("1")}
+    mapping = {"threshold": {"$decimal": "1"}}
+
+    assert config_hash(numeric) != config_hash(mapping)
+
+
 def test_material_parameter_change_changes_hash() -> None:
     baseline = {"adx_min": 22, "reward_risk": 1.5}
     changed = {"adx_min": 23, "reward_risk": 1.5}


### PR DESCRIPTION
## What changed
Implements SF-007 canonical configuration identity and hashing.

- Adds deterministic canonical JSON serialization for normalized config data
- Sorts mapping keys so key ordering does not affect identity
- Normalizes finite float/Decimal numeric values deterministically
- Adds SHA-256 config hashing
- Uses the hash itself as `ConfigId`
- Adds immutable `ConfigIdentity`
- Adds only the currently supported governance states: `experimental` and `accepted`
- Rejects unsupported/non-finite config values
- Adds unit tests for ordering, numeric formatting, material changes, immutability, and invalid values

## Why
SignalForge needs reproducible configuration identity so strategy runs can be audited and repeated independently of YAML whitespace or mapping order.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements strategy/config governance and reproducibility requirements. No strategy semantic changes.

Relates to #8.