### PR TITLE
SF-008 — Add market event and candle domain models

### DIFF
--- a/signalforge/domain/market.py
+++ b/signalforge/domain/market.py
@@ -66,7 +66,9 @@ class CompletedCandle:
     def __post_init__(self) -> None:
         if not self.source or not self.source.strip():
             raise ValueError("CompletedCandle source must not be empty")
-        if isinstance(self.source_event_count, bool) or not isinstance(self.source_event_count, int):
+        if isinstance(self.source_event_count, bool) or not isinstance(
+            self.source_event_count, int
+        ):
             raise TypeError("CompletedCandle source_event_count must be an integer")
         if self.source_event_count < 0:
             raise ValueError("CompletedCandle source_event_count must not be negative")

--- a/signalforge/domain/market.py
+++ b/signalforge/domain/market.py
@@ -1,0 +1,100 @@
+"""Broker-neutral market events and completed candle domain models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.money import Price
+from signalforge.domain.time import CandleInterval, require_aware
+
+
+class CandleQuality(StrEnum):
+    """Quality classification for canonical candle data."""
+
+    VALID = "valid"
+    INCOMPLETE = "incomplete"
+    MISSING = "missing"
+    STALE = "stale"
+    CORRUPT = "corrupt"
+
+
+@dataclass(frozen=True, slots=True)
+class MarketEvent:
+    """Normalized broker-independent observed market trade event."""
+
+    instrument_id: InstrumentId
+    exchange_timestamp: datetime
+    received_timestamp: datetime
+    price: Price
+    quantity: int
+    source: str
+    source_event_id: str | None = None
+
+    def __post_init__(self) -> None:
+        require_aware(self.exchange_timestamp)
+        require_aware(self.received_timestamp)
+        if self.price.value <= 0:
+            raise ValueError("MarketEvent price must be strictly positive")
+        if isinstance(self.quantity, bool) or not isinstance(self.quantity, int):
+            raise TypeError("MarketEvent quantity must be an integer")
+        if self.quantity <= 0:
+            raise ValueError("MarketEvent quantity must be strictly positive")
+        if not self.source or not self.source.strip():
+            raise ValueError("MarketEvent source must not be empty")
+        if self.source_event_id is not None and not self.source_event_id.strip():
+            raise ValueError("MarketEvent source_event_id must not be empty when provided")
+
+
+@dataclass(frozen=True, slots=True)
+class CompletedCandle:
+    """Immutable canonical candle fact for one closed interval."""
+
+    instrument_id: InstrumentId
+    interval: CandleInterval
+    quality: CandleQuality
+    open: Price | None
+    high: Price | None
+    low: Price | None
+    close: Price | None
+    volume: int | None
+    source: str
+    source_event_count: int
+
+    def __post_init__(self) -> None:
+        if not self.source or not self.source.strip():
+            raise ValueError("CompletedCandle source must not be empty")
+        if isinstance(self.source_event_count, bool) or not isinstance(self.source_event_count, int):
+            raise TypeError("CompletedCandle source_event_count must be an integer")
+        if self.source_event_count < 0:
+            raise ValueError("CompletedCandle source_event_count must not be negative")
+
+        prices = (self.open, self.high, self.low, self.close)
+        if self.quality is CandleQuality.MISSING:
+            if any(price is not None for price in prices) or self.volume is not None:
+                raise ValueError("MISSING candle must not fabricate OHLCV values")
+            if self.source_event_count != 0:
+                raise ValueError("MISSING candle must have zero source events")
+            return
+
+        if any(price is None for price in prices) or self.volume is None:
+            raise ValueError("Non-missing candle requires complete OHLCV values")
+
+        assert self.open is not None
+        assert self.high is not None
+        assert self.low is not None
+        assert self.close is not None
+        assert self.volume is not None
+
+        if any(price.value <= 0 for price in (self.open, self.high, self.low, self.close)):
+            raise ValueError("Candle prices must be strictly positive")
+        if isinstance(self.volume, bool) or not isinstance(self.volume, int):
+            raise TypeError("Candle volume must be an integer")
+        if self.volume < 0:
+            raise ValueError("Candle volume must not be negative")
+        if self.high.value < max(self.open.value, self.close.value, self.low.value):
+            raise ValueError("Candle high must be at least open, close, and low")
+        if self.low.value > min(self.open.value, self.close.value, self.high.value):
+            raise ValueError("Candle low must be at most open, close, and high")

--- a/tests/unit/domain/test_market.py
+++ b/tests/unit/domain/test_market.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.market import CandleQuality, CompletedCandle, MarketEvent
+from signalforge.domain.money import Price
+from signalforge.domain.time import CandleInterval
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _interval() -> CandleInterval:
+    return CandleInterval.five_minutes(datetime(2026, 8, 28, 9, 15, tzinfo=IST))
+
+
+def _candle(**overrides: object) -> CompletedCandle:
+    values: dict[str, object] = {
+        "instrument_id": InstrumentId("NSE:RELIANCE"),
+        "interval": _interval(),
+        "quality": CandleQuality.VALID,
+        "open": Price(Decimal("1380.00")),
+        "high": Price(Decimal("1382.50")),
+        "low": Price(Decimal("1379.50")),
+        "close": Price(Decimal("1381.75")),
+        "volume": 1250,
+        "source": "normalized-feed",
+        "source_event_count": 24,
+    }
+    values.update(overrides)
+    return CompletedCandle(**values)  # type: ignore[arg-type]
+
+
+def test_market_event_is_broker_neutral_and_immutable() -> None:
+    event = MarketEvent(
+        instrument_id=InstrumentId("NSE:RELIANCE"),
+        exchange_timestamp=datetime(2026, 8, 28, 9, 16, tzinfo=IST),
+        received_timestamp=datetime(2026, 8, 28, 9, 16, 0, 1000, tzinfo=IST),
+        price=Price(Decimal("1381.20")),
+        quantity=10,
+        source="normalized-feed",
+        source_event_id="trade-123",
+    )
+
+    assert event.quantity == 10
+    assert event.source == "normalized-feed"
+    with pytest.raises(FrozenInstanceError):
+        event.quantity = 11  # type: ignore[misc]
+
+
+def test_market_event_rejects_naive_timestamps() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        MarketEvent(
+            instrument_id=InstrumentId("NSE:RELIANCE"),
+            exchange_timestamp=datetime(2026, 8, 28, 9, 16),
+            received_timestamp=datetime(2026, 8, 28, 9, 16, tzinfo=IST),
+            price=Price(Decimal("1381.20")),
+            quantity=10,
+            source="normalized-feed",
+        )
+
+
+def test_market_event_requires_positive_price_and_quantity() -> None:
+    with pytest.raises(ValueError, match="price must be strictly positive"):
+        MarketEvent(
+            InstrumentId("NSE:RELIANCE"),
+            datetime(2026, 8, 28, 9, 16, tzinfo=IST),
+            datetime(2026, 8, 28, 9, 16, tzinfo=IST),
+            Price(Decimal("0")),
+            10,
+            "normalized-feed",
+        )
+
+    with pytest.raises(ValueError, match="quantity must be strictly positive"):
+        MarketEvent(
+            InstrumentId("NSE:RELIANCE"),
+            datetime(2026, 8, 28, 9, 16, tzinfo=IST),
+            datetime(2026, 8, 28, 9, 16, tzinfo=IST),
+            Price(Decimal("1381.20")),
+            0,
+            "normalized-feed",
+        )
+
+
+def test_completed_candle_is_immutable() -> None:
+    candle = _candle()
+
+    with pytest.raises(FrozenInstanceError):
+        candle.volume = 1300  # type: ignore[misc]
+
+
+def test_candle_quality_contains_required_states() -> None:
+    assert {quality.value for quality in CandleQuality} == {
+        "valid",
+        "incomplete",
+        "missing",
+        "stale",
+        "corrupt",
+    }
+
+
+def test_valid_candle_enforces_ohlc_invariants() -> None:
+    with pytest.raises(ValueError, match="Candle high"):
+        _candle(high=Price(Decimal("1381.00")))
+
+    with pytest.raises(ValueError, match="Candle low"):
+        _candle(low=Price(Decimal("1381.90")))
+
+
+def test_non_missing_candle_requires_complete_ohlcv() -> None:
+    with pytest.raises(ValueError, match="complete OHLCV"):
+        _candle(close=None)
+
+    with pytest.raises(ValueError, match="complete OHLCV"):
+        _candle(volume=None)
+
+
+def test_candle_volume_must_be_non_negative_integer() -> None:
+    with pytest.raises(ValueError, match="must not be negative"):
+        _candle(volume=-1)
+
+    with pytest.raises(TypeError, match="must be an integer"):
+        _candle(volume=True)
+
+
+def test_missing_candle_has_no_fabricated_ohlcv() -> None:
+    missing = _candle(
+        quality=CandleQuality.MISSING,
+        open=None,
+        high=None,
+        low=None,
+        close=None,
+        volume=None,
+        source_event_count=0,
+    )
+
+    assert missing.quality is CandleQuality.MISSING
+    assert missing.open is None
+    assert missing.volume is None
+
+
+def test_missing_candle_rejects_fabricated_values_or_events() -> None:
+    with pytest.raises(ValueError, match="must not fabricate"):
+        _candle(quality=CandleQuality.MISSING, source_event_count=0)
+
+    with pytest.raises(ValueError, match="zero source events"):
+        _candle(
+            quality=CandleQuality.MISSING,
+            open=None,
+            high=None,
+            low=None,
+            close=None,
+            volume=None,
+            source_event_count=1,
+        )


### PR DESCRIPTION
## What changed
Implements SF-008 broker-neutral market domain models.

- Adds immutable `MarketEvent` with instrument identity, exchange/received timestamps, price, quantity and provenance
- Adds `CandleQuality` with VALID, INCOMPLETE, MISSING, STALE and CORRUPT
- Adds immutable `CompletedCandle` over a canonical `CandleInterval`
- Enforces positive market prices/quantities, non-negative candle volume and OHLC consistency
- Represents MISSING candles explicitly without fabricated OHLCV values or source events
- Keeps all models independent of broker SDK types
- Adds unit tests for immutability, timestamp safety, OHLC/volume invariants and missing-candle semantics

## Why
M1 needs broker-neutral market facts that can be shared across replay, paper and live runtimes without silent data repair or broker coupling.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002/ADR-005 market-domain contract. No strategy semantic changes.

Relates to #9.