### PR TITLE
SF-009 — Add indicator snapshot contract

### DIFF
--- a/signalforge/domain/indicators.py
+++ b/signalforge/domain/indicators.py
@@ -1,0 +1,55 @@
+"""Immutable indicator result contract for SignalForge strategy consumers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.time import CandleInterval
+
+
+@dataclass(frozen=True, slots=True)
+class IndicatorSnapshot:
+    """Indicator values produced for one completed canonical candle."""
+
+    instrument_id: InstrumentId
+    interval: CandleInterval
+    ready: bool
+    calculation_version: str
+    ema9: Decimal | None = None
+    ema20: Decimal | None = None
+    ema50: Decimal | None = None
+    rsi14: Decimal | None = None
+    adx14: Decimal | None = None
+    macd_line: Decimal | None = None
+    macd_signal: Decimal | None = None
+    macd_histogram: Decimal | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.ready, bool):
+            raise TypeError("IndicatorSnapshot ready must be a boolean")
+        if not self.calculation_version or not self.calculation_version.strip():
+            raise ValueError("IndicatorSnapshot calculation_version must not be empty")
+
+        values = self._values()
+        for name, value in values.items():
+            if value is not None and not isinstance(value, Decimal):
+                raise TypeError(f"IndicatorSnapshot {name} must be a Decimal when provided")
+            if value is not None and not value.is_finite():
+                raise ValueError(f"IndicatorSnapshot {name} must be finite when provided")
+
+        if self.ready and any(value is None for value in values.values()):
+            raise ValueError("Ready IndicatorSnapshot requires all indicator values")
+
+    def _values(self) -> dict[str, Decimal | None]:
+        return {
+            "ema9": self.ema9,
+            "ema20": self.ema20,
+            "ema50": self.ema50,
+            "rsi14": self.rsi14,
+            "adx14": self.adx14,
+            "macd_line": self.macd_line,
+            "macd_signal": self.macd_signal,
+            "macd_histogram": self.macd_histogram,
+        }

--- a/tests/unit/domain/test_indicators.py
+++ b/tests/unit/domain/test_indicators.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.indicators import IndicatorSnapshot
+from signalforge.domain.time import CandleInterval
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _interval() -> CandleInterval:
+    return CandleInterval.five_minutes(datetime(2026, 8, 28, 9, 20, tzinfo=IST))
+
+
+def _ready_snapshot(**overrides: object) -> IndicatorSnapshot:
+    values: dict[str, object] = {
+        "instrument_id": InstrumentId("NSE:RELIANCE"),
+        "interval": _interval(),
+        "ready": True,
+        "calculation_version": "indicators-v1",
+        "ema9": Decimal("1380.10"),
+        "ema20": Decimal("1378.20"),
+        "ema50": Decimal("1370.00"),
+        "rsi14": Decimal("61.5"),
+        "adx14": Decimal("25.2"),
+        "macd_line": Decimal("2.4"),
+        "macd_signal": Decimal("1.8"),
+        "macd_histogram": Decimal("0.6"),
+    }
+    values.update(overrides)
+    return IndicatorSnapshot(**values)  # type: ignore[arg-type]
+
+
+def test_ready_snapshot_is_immutable_and_retains_version() -> None:
+    snapshot = _ready_snapshot()
+
+    assert snapshot.ready is True
+    assert snapshot.calculation_version == "indicators-v1"
+    assert snapshot.rsi14 == Decimal("61.5")
+
+    with pytest.raises(FrozenInstanceError):
+        snapshot.ready = False  # type: ignore[misc]
+
+
+def test_unready_snapshot_may_contain_partial_seeded_values() -> None:
+    snapshot = IndicatorSnapshot(
+        instrument_id=InstrumentId("NSE:RELIANCE"),
+        interval=_interval(),
+        ready=False,
+        calculation_version="indicators-v1",
+        ema9=Decimal("1380.10"),
+        ema20=Decimal("1378.20"),
+    )
+
+    assert snapshot.ready is False
+    assert snapshot.ema9 == Decimal("1380.10")
+    assert snapshot.adx14 is None
+
+
+def test_ready_snapshot_requires_complete_indicator_set() -> None:
+    with pytest.raises(ValueError, match="requires all indicator values"):
+        _ready_snapshot(adx14=None)
+
+
+def test_readiness_is_not_inferred_from_non_null_values() -> None:
+    snapshot = _ready_snapshot(ready=False)
+
+    assert snapshot.ready is False
+    assert snapshot.adx14 is not None
+
+
+def test_indicator_values_must_be_decimal_when_present() -> None:
+    with pytest.raises(TypeError, match="rsi14 must be a Decimal"):
+        _ready_snapshot(rsi14=61.5)
+
+
+def test_indicator_values_must_be_finite() -> None:
+    with pytest.raises(ValueError, match="macd_line must be finite"):
+        _ready_snapshot(macd_line=Decimal("Infinity"))
+
+
+def test_calculation_version_must_be_non_empty() -> None:
+    with pytest.raises(ValueError, match="calculation_version"):
+        _ready_snapshot(calculation_version=" ")
+
+
+def test_ready_must_be_boolean() -> None:
+    with pytest.raises(TypeError, match="ready must be a boolean"):
+        _ready_snapshot(ready=1)


### PR DESCRIPTION
## What changed
Implements SF-009 immutable indicator snapshot domain contract.

- Adds immutable `IndicatorSnapshot` linked to instrument and completed-candle interval
- Carries EMA9, EMA20, EMA50, RSI14, ADX14, MACD line/signal/histogram
- Uses explicit `ready` metadata rather than inferring readiness from null values
- Allows partially seeded values while unready
- Requires the full indicator set when marked ready
- Retains non-empty `calculation_version` provenance
- Uses finite `Decimal` values for deterministic numeric transport
- Adds unit tests for immutability, readiness semantics, type safety, finite values and version retention

## Why
Strategy consumers need a stable result contract before the M2 indicator algorithms are implemented, especially because EMA/ADX/MACD seeding can produce partial values before the complete snapshot is actionable.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-006 result contract only. Indicator algorithms remain in M2. No strategy semantic changes.

Relates to #10.