### PR TITLE
SF-010 — Add strategy evaluation models

### DIFF
--- a/signalforge/domain/strategy.py
+++ b/signalforge/domain/strategy.py
@@ -1,0 +1,128 @@
+"""Typed strategy evaluation results and stable decision reasons."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.time import CandleInterval
+
+
+class DecisionReason(StrEnum):
+    """Stable machine-readable strategy decision reason codes."""
+
+    QUALIFIED = "qualified"
+    ACTIONABLE = "actionable"
+    QUALIFIED_NOT_ACTIONABLE = "qualified_not_actionable"
+    TREND_NOT_MET = "trend_not_met"
+    MOMENTUM_NOT_MET = "momentum_not_met"
+    SETUP_NOT_MET = "setup_not_met"
+
+
+@dataclass(frozen=True, slots=True)
+class TrendResult:
+    """Result of the strategy trend component."""
+
+    passed: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.passed, bool):
+            raise TypeError("TrendResult passed must be a boolean")
+
+
+@dataclass(frozen=True, slots=True)
+class MomentumResult:
+    """Result of the V1 momentum component with diagnostic MACD metadata."""
+
+    passed: bool
+    rsi_passed: bool
+    adx_passed: bool
+    macd_signal_positive: bool | None = None
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("passed", self.passed),
+            ("rsi_passed", self.rsi_passed),
+            ("adx_passed", self.adx_passed),
+        ):
+            if not isinstance(value, bool):
+                raise TypeError(f"MomentumResult {name} must be a boolean")
+
+        if self.macd_signal_positive is not None and not isinstance(
+            self.macd_signal_positive, bool
+        ):
+            raise TypeError("MomentumResult macd_signal_positive must be a boolean when provided")
+
+        if self.passed != (self.rsi_passed and self.adx_passed):
+            raise ValueError("MomentumResult passed must equal RSI AND ADX results")
+
+
+@dataclass(frozen=True, slots=True)
+class SetupResult:
+    """Result of the strategy setup component."""
+
+    passed: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.passed, bool):
+            raise TypeError("SetupResult passed must be a boolean")
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyEvaluation:
+    """Immutable strategy decision for one instrument and completed candle."""
+
+    instrument_id: InstrumentId
+    interval: CandleInterval
+    trend: TrendResult
+    momentum: MomentumResult
+    setup: SetupResult
+    qualified: bool
+    actionable: bool
+    reasons: tuple[DecisionReason, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.qualified, bool):
+            raise TypeError("StrategyEvaluation qualified must be a boolean")
+        if not isinstance(self.actionable, bool):
+            raise TypeError("StrategyEvaluation actionable must be a boolean")
+
+        expected_qualified = self.trend.passed and self.momentum.passed and self.setup.passed
+        if self.qualified != expected_qualified:
+            raise ValueError("StrategyEvaluation qualified must equal trend AND momentum AND setup")
+        if self.actionable and not self.qualified:
+            raise ValueError("StrategyEvaluation actionable requires qualified")
+
+        expected_reasons = _expected_reasons(
+            trend=self.trend,
+            momentum=self.momentum,
+            setup=self.setup,
+            qualified=self.qualified,
+            actionable=self.actionable,
+        )
+        if self.reasons != expected_reasons:
+            raise ValueError("StrategyEvaluation reasons do not match evaluation state")
+
+
+def _expected_reasons(
+    *,
+    trend: TrendResult,
+    momentum: MomentumResult,
+    setup: SetupResult,
+    qualified: bool,
+    actionable: bool,
+) -> tuple[DecisionReason, ...]:
+    if qualified:
+        if actionable:
+            return (DecisionReason.QUALIFIED, DecisionReason.ACTIONABLE)
+        return (DecisionReason.QUALIFIED, DecisionReason.QUALIFIED_NOT_ACTIONABLE)
+
+    reasons: list[DecisionReason] = []
+    if not trend.passed:
+        reasons.append(DecisionReason.TREND_NOT_MET)
+    if not momentum.passed:
+        reasons.append(DecisionReason.MOMENTUM_NOT_MET)
+    if not setup.passed:
+        reasons.append(DecisionReason.SETUP_NOT_MET)
+    return tuple(reasons)

--- a/tests/unit/domain/test_strategy.py
+++ b/tests/unit/domain/test_strategy.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.strategy import (
+    DecisionReason,
+    MomentumResult,
+    SetupResult,
+    StrategyEvaluation,
+    TrendResult,
+)
+from signalforge.domain.time import CandleInterval
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _interval() -> CandleInterval:
+    return CandleInterval.five_minutes(datetime(2026, 8, 28, 10, 0, tzinfo=IST))
+
+
+def _evaluation(
+    *,
+    trend: bool = True,
+    rsi: bool = True,
+    adx: bool = True,
+    setup: bool = True,
+    actionable: bool = True,
+    macd_signal_positive: bool | None = True,
+) -> StrategyEvaluation:
+    trend_result = TrendResult(trend)
+    momentum_result = MomentumResult(
+        passed=rsi and adx,
+        rsi_passed=rsi,
+        adx_passed=adx,
+        macd_signal_positive=macd_signal_positive,
+    )
+    setup_result = SetupResult(setup)
+    qualified = trend and rsi and adx and setup
+
+    if qualified:
+        reasons = (
+            (DecisionReason.QUALIFIED, DecisionReason.ACTIONABLE)
+            if actionable
+            else (DecisionReason.QUALIFIED, DecisionReason.QUALIFIED_NOT_ACTIONABLE)
+        )
+    else:
+        reason_list: list[DecisionReason] = []
+        if not trend:
+            reason_list.append(DecisionReason.TREND_NOT_MET)
+        if not (rsi and adx):
+            reason_list.append(DecisionReason.MOMENTUM_NOT_MET)
+        if not setup:
+            reason_list.append(DecisionReason.SETUP_NOT_MET)
+        reasons = tuple(reason_list)
+
+    return StrategyEvaluation(
+        instrument_id=InstrumentId("NSE:RELIANCE"),
+        interval=_interval(),
+        trend=trend_result,
+        momentum=momentum_result,
+        setup=setup_result,
+        qualified=qualified,
+        actionable=actionable if qualified else False,
+        reasons=reasons,
+    )
+
+
+def test_qualified_actionable_evaluation_is_immutable() -> None:
+    evaluation = _evaluation()
+
+    assert evaluation.qualified is True
+    assert evaluation.actionable is True
+    assert evaluation.reasons == (DecisionReason.QUALIFIED, DecisionReason.ACTIONABLE)
+
+    with pytest.raises(FrozenInstanceError):
+        evaluation.actionable = False  # type: ignore[misc]
+
+
+def test_qualified_evaluation_may_be_non_actionable() -> None:
+    evaluation = _evaluation(actionable=False)
+
+    assert evaluation.qualified is True
+    assert evaluation.actionable is False
+    assert evaluation.reasons == (
+        DecisionReason.QUALIFIED,
+        DecisionReason.QUALIFIED_NOT_ACTIONABLE,
+    )
+
+
+def test_actionable_requires_qualified() -> None:
+    with pytest.raises(ValueError, match="actionable requires qualified"):
+        StrategyEvaluation(
+            instrument_id=InstrumentId("NSE:RELIANCE"),
+            interval=_interval(),
+            trend=TrendResult(False),
+            momentum=MomentumResult(True, True, True),
+            setup=SetupResult(True),
+            qualified=False,
+            actionable=True,
+            reasons=(DecisionReason.TREND_NOT_MET,),
+        )
+
+
+def test_qualification_must_equal_component_conjunction() -> None:
+    with pytest.raises(ValueError, match="qualified must equal"):
+        StrategyEvaluation(
+            instrument_id=InstrumentId("NSE:RELIANCE"),
+            interval=_interval(),
+            trend=TrendResult(True),
+            momentum=MomentumResult(True, True, True),
+            setup=SetupResult(False),
+            qualified=True,
+            actionable=False,
+            reasons=(DecisionReason.QUALIFIED, DecisionReason.QUALIFIED_NOT_ACTIONABLE),
+        )
+
+
+def test_failed_components_use_stable_reason_codes() -> None:
+    evaluation = _evaluation(trend=False, rsi=False, setup=False)
+
+    assert evaluation.qualified is False
+    assert evaluation.reasons == (
+        DecisionReason.TREND_NOT_MET,
+        DecisionReason.MOMENTUM_NOT_MET,
+        DecisionReason.SETUP_NOT_MET,
+    )
+
+
+def test_reasons_must_match_evaluation_state() -> None:
+    with pytest.raises(ValueError, match="reasons do not match"):
+        StrategyEvaluation(
+            instrument_id=InstrumentId("NSE:RELIANCE"),
+            interval=_interval(),
+            trend=TrendResult(True),
+            momentum=MomentumResult(True, True, True),
+            setup=SetupResult(True),
+            qualified=True,
+            actionable=False,
+            reasons=(DecisionReason.QUALIFIED,),
+        )
+
+
+def test_macd_metadata_cannot_change_v1_momentum_result() -> None:
+    positive = _evaluation(macd_signal_positive=True)
+    negative = _evaluation(macd_signal_positive=False)
+    missing = _evaluation(macd_signal_positive=None)
+
+    assert positive.momentum.passed is True
+    assert negative.momentum.passed is True
+    assert missing.momentum.passed is True
+    assert positive.qualified == negative.qualified == missing.qualified is True
+
+
+def test_momentum_passed_must_equal_rsi_and_adx() -> None:
+    with pytest.raises(ValueError, match="must equal RSI AND ADX"):
+        MomentumResult(
+            passed=True,
+            rsi_passed=True,
+            adx_passed=False,
+            macd_signal_positive=True,
+        )
+
+
+def test_result_booleans_are_strict() -> None:
+    with pytest.raises(TypeError, match="TrendResult passed"):
+        TrendResult(1)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="SetupResult passed"):
+        SetupResult(1)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="macd_signal_positive"):
+        MomentumResult(True, True, True, macd_signal_positive=1)  # type: ignore[arg-type]


### PR DESCRIPTION
## What changed
Implements SF-010 typed strategy evaluation result models.

- Adds immutable `TrendResult`, `MomentumResult`, `SetupResult`, and `StrategyEvaluation`
- Adds stable machine-readable `DecisionReason` codes
- Enforces V1 qualification as trend AND momentum AND setup
- Enforces `actionable => qualified`
- Allows qualified evaluations to be non-actionable
- Encodes momentum pass as RSI AND ADX only
- Carries MACD signal positivity as diagnostic metadata that cannot affect qualification
- Validates reason codes against the evaluation state
- Adds unit tests for immutability, reason stability, qualification/actionability invariants, and MACD non-participation

## Why
SignalForge needs a stable strategy-decision contract before implementing evaluator logic so replay, paper, and live paths can consume the same deterministic result model.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002/ADR-004 strategy-evaluation contract. No strategy semantic changes.

Relates to #11.