### PR TITLE
SF-011 — Add immutable signal domain model

### DIFF
--- a/signalforge/domain/signals.py
+++ b/signalforge/domain/signals.py
@@ -1,0 +1,76 @@
+"""Immutable qualifying-signal domain fact."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from signalforge.domain.ids import InstrumentId, SignalId, deterministic_id
+from signalforge.domain.money import Price
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.time import CandleInterval, require_aware
+
+
+@dataclass(frozen=True, slots=True)
+class Signal:
+    """Immutable signal derived from an actionable strategy evaluation."""
+
+    signal_id: SignalId
+    instrument_id: InstrumentId
+    interval: CandleInterval
+    signal_close: Price
+    signal_low: Price
+    run: RunIdentity
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        require_aware(self.created_at)
+        if self.signal_close.value <= 0:
+            raise ValueError("Signal close must be strictly positive")
+        if self.signal_low.value <= 0:
+            raise ValueError("Signal low must be strictly positive")
+        if self.signal_low.value > self.signal_close.value:
+            raise ValueError("Signal low must not exceed signal close")
+        if self.signal_id != self.expected_id():
+            raise ValueError("Signal ID does not match deterministic logical identity")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        instrument_id: InstrumentId,
+        interval: CandleInterval,
+        signal_close: Price,
+        signal_low: Price,
+        run: RunIdentity,
+        created_at: datetime,
+    ) -> Signal:
+        """Create a signal with its deterministic identity derived from logical facts."""
+
+        signal_id = deterministic_id(
+            SignalId,
+            str(run.run_id),
+            str(instrument_id),
+            interval.start.isoformat(),
+            interval.end.isoformat(),
+        )
+        return cls(
+            signal_id=signal_id,
+            instrument_id=instrument_id,
+            interval=interval,
+            signal_close=signal_close,
+            signal_low=signal_low,
+            run=run,
+            created_at=created_at,
+        )
+
+    def expected_id(self) -> SignalId:
+        """Return the deterministic ID implied by the signal's logical identity."""
+
+        return deterministic_id(
+            SignalId,
+            str(self.run.run_id),
+            str(self.instrument_id),
+            self.interval.start.isoformat(),
+            self.interval.end.isoformat(),
+        )

--- a/tests/unit/domain/test_signals.py
+++ b/tests/unit/domain/test_signals.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.ids import ConfigId, InstrumentId, RunId, SignalId
+from signalforge.domain.money import Price
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.time import CandleInterval
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-001"),
+        config_hash="abc123",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _interval() -> CandleInterval:
+    return CandleInterval.five_minutes(datetime(2026, 8, 28, 10, 0, tzinfo=IST))
+
+
+def _signal(**overrides: object) -> Signal:
+    values: dict[str, object] = {
+        "instrument_id": InstrumentId("NSE:RELIANCE"),
+        "interval": _interval(),
+        "signal_close": Price(Decimal("1381.75")),
+        "signal_low": Price(Decimal("1379.50")),
+        "run": _run(),
+        "created_at": datetime(2026, 8, 28, 10, 5, tzinfo=IST),
+    }
+    values.update(overrides)
+    return Signal.create(**values)  # type: ignore[arg-type]
+
+
+def test_signal_is_immutable_and_retains_candle_anchors() -> None:
+    signal = _signal()
+
+    assert signal.signal_close == Price(Decimal("1381.75"))
+    assert signal.signal_low == Price(Decimal("1379.50"))
+    assert signal.run.strategy.strategy_version == "1.0.0"
+
+    with pytest.raises(FrozenInstanceError):
+        signal.signal_low = Price(Decimal("1378.00"))  # type: ignore[misc]
+
+
+def test_signal_identity_is_deterministic_from_logical_facts() -> None:
+    first = _signal(created_at=datetime(2026, 8, 28, 10, 5, tzinfo=IST))
+    second = _signal(created_at=datetime(2026, 8, 28, 10, 5, 1, tzinfo=IST))
+
+    assert first.signal_id == second.signal_id
+
+
+def test_signal_identity_changes_when_logical_identity_changes() -> None:
+    first = _signal()
+    second = _signal(instrument_id=InstrumentId("NSE:TCS"))
+
+    assert first.signal_id != second.signal_id
+
+
+def test_signal_rejects_non_deterministic_id() -> None:
+    valid = _signal()
+
+    with pytest.raises(ValueError, match="deterministic logical identity"):
+        Signal(
+            signal_id=SignalId("wrong-id"),
+            instrument_id=valid.instrument_id,
+            interval=valid.interval,
+            signal_close=valid.signal_close,
+            signal_low=valid.signal_low,
+            run=valid.run,
+            created_at=valid.created_at,
+        )
+
+
+def test_signal_rejects_naive_creation_timestamp() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        _signal(created_at=datetime(2026, 8, 28, 10, 5))
+
+
+def test_signal_prices_must_be_positive_and_low_not_above_close() -> None:
+    with pytest.raises(ValueError, match="close must be strictly positive"):
+        _signal(signal_close=Price(Decimal("0")))
+
+    with pytest.raises(ValueError, match="low must be strictly positive"):
+        _signal(signal_low=Price(Decimal("0")))
+
+    with pytest.raises(ValueError, match="low must not exceed signal close"):
+        _signal(signal_low=Price(Decimal("1382.00")))
+
+
+def test_signal_contains_no_mutable_lifecycle_state() -> None:
+    field_names = set(Signal.__dataclass_fields__)
+
+    assert "state" not in field_names
+    assert "status" not in field_names
+    assert "armed" not in field_names
+    assert "triggered" not in field_names


### PR DESCRIPTION
## What changed
Implements SF-011 immutable Signal domain fact.

- Adds immutable `Signal` with deterministic `SignalId`
- Anchors the signal to instrument and completed signal-candle interval
- Persists signal close and signal low as immutable candle facts
- Retains full `RunIdentity` provenance including strategy/config/run identity
- Retains timezone-aware creation timestamp
- Enforces positive signal prices and `signal_low <= signal_close`
- Validates supplied signal IDs against the deterministic logical identity
- Keeps lifecycle state out of the Signal model
- Adds unit tests for immutability, deterministic identity, timestamp safety, price invariants, provenance, and absence of lifecycle fields

## Identity semantics
Signal identity is derived from run ID + instrument ID + signal candle interval. Creation timestamp is deliberately excluded so replay/recovery of the same logical signal produces the same ID.

## Scope boundary
Raw/tradable trigger prices and ARMED/TRIGGERED/EXPIRED state are intentionally excluded; those belong to the subsequent signal-lifecycle models.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002 signal-domain separation. No strategy semantic changes.

Relates to #12.