### PR TITLE
SF-012 — Add ArmedSetup state machine

### DIFF
--- a/signalforge/domain/armed.py
+++ b/signalforge/domain/armed.py
@@ -24,7 +24,7 @@ class ExpiryReason(StrEnum):
     ENTRY_CUTOFF_REACHED = "entry_cutoff_reached"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class ArmedSetup:
     """Controlled state machine derived from one immutable Signal."""
 
@@ -83,6 +83,10 @@ class ArmedSetup:
         elif self.state is ArmedSetupState.TRIGGERED:
             if self.terminal_at is None or self.expiry_reason is not None:
                 raise ValueError("TRIGGERED setup requires terminal_at and no expiry_reason")
+            if not self.armed_at <= self.terminal_at < self.valid_until:
+                raise ValueError("TRIGGERED setup terminal_at must be within validity window")
         elif self.state is ArmedSetupState.EXPIRED:
             if self.terminal_at is None or self.expiry_reason is None:
                 raise ValueError("EXPIRED setup requires terminal_at and expiry_reason")
+            if self.terminal_at < self.armed_at:
+                raise ValueError("EXPIRED setup terminal_at must not precede arming")

--- a/signalforge/domain/armed.py
+++ b/signalforge/domain/armed.py
@@ -1,0 +1,88 @@
+"""Armed setup lifecycle for qualifying Signal facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from signalforge.domain.ids import SignalId
+from signalforge.domain.money import Price
+from signalforge.domain.states import InvalidStateTransition
+from signalforge.domain.time import require_aware
+
+
+class ArmedSetupState(StrEnum):
+    ARMED = "armed"
+    TRIGGERED = "triggered"
+    EXPIRED = "expired"
+
+
+class ExpiryReason(StrEnum):
+    SIGNAL_LOW_BREACH = "signal_low_breach"
+    VALIDITY_WINDOW_END = "validity_window_end"
+    ENTRY_CUTOFF_REACHED = "entry_cutoff_reached"
+
+
+@dataclass(frozen=True, slots=True)
+class ArmedSetup:
+    """Controlled state machine derived from one immutable Signal."""
+
+    signal_id: SignalId
+    raw_trigger: Price
+    tradable_trigger: Price
+    signal_low: Price
+    armed_at: datetime
+    valid_until: datetime
+    state: ArmedSetupState = ArmedSetupState.ARMED
+    terminal_at: datetime | None = None
+    expiry_reason: ExpiryReason | None = None
+
+    def __post_init__(self) -> None:
+        require_aware(self.armed_at)
+        require_aware(self.valid_until)
+        if self.valid_until <= self.armed_at:
+            raise ValueError("ArmedSetup valid_until must be after armed_at")
+        if self.raw_trigger.value <= 0 or self.tradable_trigger.value <= 0:
+            raise ValueError("ArmedSetup trigger prices must be strictly positive")
+        if self.signal_low.value <= 0:
+            raise ValueError("ArmedSetup signal_low must be strictly positive")
+        if self.tradable_trigger.value < self.raw_trigger.value:
+            raise ValueError("ArmedSetup tradable_trigger must not be below raw_trigger")
+        self._validate_terminal_metadata()
+
+    def trigger(self, *, at: datetime) -> None:
+        self._require_armed()
+        require_aware(at)
+        if not self.armed_at <= at < self.valid_until:
+            raise ValueError("Trigger timestamp must fall within the setup validity window")
+        object.__setattr__(self, "state", ArmedSetupState.TRIGGERED)
+        object.__setattr__(self, "terminal_at", at)
+
+    def expire(self, *, at: datetime, reason: ExpiryReason) -> None:
+        self._require_armed()
+        require_aware(at)
+        if at < self.armed_at:
+            raise ValueError("Expiry timestamp must not precede arming")
+        object.__setattr__(self, "state", ArmedSetupState.EXPIRED)
+        object.__setattr__(self, "terminal_at", at)
+        object.__setattr__(self, "expiry_reason", reason)
+
+    def _require_armed(self) -> None:
+        if self.state is not ArmedSetupState.ARMED:
+            raise InvalidStateTransition(
+                f"Cannot transition ArmedSetup from terminal state {self.state.value}"
+            )
+
+    def _validate_terminal_metadata(self) -> None:
+        if self.terminal_at is not None:
+            require_aware(self.terminal_at)
+        if self.state is ArmedSetupState.ARMED:
+            if self.terminal_at is not None or self.expiry_reason is not None:
+                raise ValueError("ARMED setup cannot have terminal metadata")
+        elif self.state is ArmedSetupState.TRIGGERED:
+            if self.terminal_at is None or self.expiry_reason is not None:
+                raise ValueError("TRIGGERED setup requires terminal_at and no expiry_reason")
+        elif self.state is ArmedSetupState.EXPIRED:
+            if self.terminal_at is None or self.expiry_reason is None:
+                raise ValueError("EXPIRED setup requires terminal_at and expiry_reason")

--- a/signalforge/domain/states.py
+++ b/signalforge/domain/states.py
@@ -1,0 +1,5 @@
+"""Shared domain state-machine errors."""
+
+
+class InvalidStateTransition(ValueError):
+    """Raised when a domain entity is asked to perform an illegal state transition."""

--- a/tests/unit/domain/test_armed.py
+++ b/tests/unit/domain/test_armed.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timedelta
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.armed import ArmedSetup, ArmedSetupState, ExpiryReason
+from signalforge.domain.ids import SignalId
+from signalforge.domain.money import Price
+from signalforge.domain.states import InvalidStateTransition
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _setup() -> ArmedSetup:
+    armed_at = datetime(2026, 8, 28, 10, 5, tzinfo=IST)
+    return ArmedSetup(
+        signal_id=SignalId("signal-001"),
+        raw_trigger=Price(Decimal("1383.13175")),
+        tradable_trigger=Price(Decimal("1383.15")),
+        signal_low=Price(Decimal("1379.50")),
+        armed_at=armed_at,
+        valid_until=armed_at + timedelta(minutes=5),
+    )
+
+
+def test_new_setup_starts_armed_with_immutable_anchors() -> None:
+    setup = _setup()
+
+    assert setup.state is ArmedSetupState.ARMED
+    assert setup.terminal_at is None
+    assert setup.expiry_reason is None
+
+    with pytest.raises(FrozenInstanceError):
+        setup.signal_low = Price(Decimal("1378.00"))  # type: ignore[misc]
+
+
+def test_armed_setup_can_trigger_once() -> None:
+    setup = _setup()
+    triggered_at = setup.armed_at + timedelta(minutes=1)
+
+    setup.trigger(at=triggered_at)
+
+    assert setup.state is ArmedSetupState.TRIGGERED
+    assert setup.terminal_at == triggered_at
+    assert setup.expiry_reason is None
+
+    with pytest.raises(InvalidStateTransition):
+        setup.expire(at=triggered_at, reason=ExpiryReason.SIGNAL_LOW_BREACH)
+
+
+def test_armed_setup_can_expire_with_stable_reason() -> None:
+    setup = _setup()
+    expired_at = setup.valid_until
+
+    setup.expire(at=expired_at, reason=ExpiryReason.VALIDITY_WINDOW_END)
+
+    assert setup.state is ArmedSetupState.EXPIRED
+    assert setup.terminal_at == expired_at
+    assert setup.expiry_reason is ExpiryReason.VALIDITY_WINDOW_END
+
+    with pytest.raises(InvalidStateTransition):
+        setup.trigger(at=expired_at)
+
+
+def test_expiry_reasons_cover_frozen_v1_causes() -> None:
+    assert {reason.value for reason in ExpiryReason} == {
+        "signal_low_breach",
+        "validity_window_end",
+        "entry_cutoff_reached",
+    }
+
+
+def test_trigger_must_be_inside_validity_window() -> None:
+    setup = _setup()
+
+    with pytest.raises(ValueError, match="validity window"):
+        setup.trigger(at=setup.valid_until)
+
+
+def test_setup_validates_immutable_price_and_time_anchors() -> None:
+    armed_at = datetime(2026, 8, 28, 10, 5, tzinfo=IST)
+
+    with pytest.raises(ValueError, match="valid_until"):
+        ArmedSetup(
+            signal_id=SignalId("signal-001"),
+            raw_trigger=Price(Decimal("100")),
+            tradable_trigger=Price(Decimal("100")),
+            signal_low=Price(Decimal("99")),
+            armed_at=armed_at,
+            valid_until=armed_at,
+        )
+
+    with pytest.raises(ValueError, match="tradable_trigger"):
+        ArmedSetup(
+            signal_id=SignalId("signal-001"),
+            raw_trigger=Price(Decimal("100.02")),
+            tradable_trigger=Price(Decimal("100.00")),
+            signal_low=Price(Decimal("99")),
+            armed_at=armed_at,
+            valid_until=armed_at + timedelta(minutes=5),
+        )
+
+
+def test_setup_rejects_naive_timestamps() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        ArmedSetup(
+            signal_id=SignalId("signal-001"),
+            raw_trigger=Price(Decimal("100")),
+            tradable_trigger=Price(Decimal("100")),
+            signal_low=Price(Decimal("99")),
+            armed_at=datetime(2026, 8, 28, 10, 5),
+            valid_until=datetime(2026, 8, 28, 10, 10, tzinfo=IST),
+        )


### PR DESCRIPTION
## What changed
Implements SF-012 explicit ArmedSetup lifecycle.

- Adds `ArmedSetupState`: ARMED, TRIGGERED, EXPIRED
- Adds stable `ExpiryReason` codes for signal-low breach, validity-window end, and entry cutoff
- Adds controlled `ArmedSetup` state machine with immutable trigger/signal-low/validity anchors
- Stores raw and tradable trigger prices and enforces tradable >= raw
- Enforces legal transitions ARMED -> TRIGGERED and ARMED -> EXPIRED only
- Makes TRIGGERED and EXPIRED terminal
- Adds specific `InvalidStateTransition` domain error for illegal transitions
- Retains terminal timestamp and expiry reason where applicable
- Adds unit tests for transition legality, terminal behavior, immutable anchors, validity-window semantics, and timestamp safety

## Scope boundary
No fill, TriggerEvent, Trade, Position, or execution behavior is implemented here.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002 signal lifecycle. No strategy semantic changes.

Relates to #13.