### PR TITLE
SF-013 — Add trigger and execution domain facts

### DIFF
--- a/signalforge/domain/execution.py
+++ b/signalforge/domain/execution.py
@@ -1,0 +1,219 @@
+"""Broker-independent trigger and execution domain facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from signalforge.domain.ids import (
+    EntryIntentId,
+    FillId,
+    InstrumentId,
+    SignalId,
+    TriggerEventId,
+    deterministic_id,
+)
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.time import require_aware
+
+
+class ExecutionMode(StrEnum):
+    PAPER = "paper"
+    LIVE = "live"
+
+
+@dataclass(frozen=True, slots=True)
+class TriggerEvent:
+    """Immutable evidence that an observed trade crossed an armed trigger."""
+
+    trigger_event_id: TriggerEventId
+    signal_id: SignalId
+    instrument_id: InstrumentId
+    reference_price: Price
+    observed_price: Price
+    observed_at: datetime
+    run: RunIdentity
+
+    def __post_init__(self) -> None:
+        require_aware(self.observed_at)
+        if self.reference_price.value <= 0 or self.observed_price.value <= 0:
+            raise ValueError("TriggerEvent prices must be strictly positive")
+        if self.observed_price.value < self.reference_price.value:
+            raise ValueError("TriggerEvent observed_price must meet or exceed reference_price")
+        if self.trigger_event_id != self.expected_id():
+            raise ValueError("TriggerEvent ID does not match deterministic logical identity")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        signal_id: SignalId,
+        instrument_id: InstrumentId,
+        reference_price: Price,
+        observed_price: Price,
+        observed_at: datetime,
+        run: RunIdentity,
+    ) -> TriggerEvent:
+        event_id = deterministic_id(
+            TriggerEventId,
+            str(run.run_id),
+            str(signal_id),
+            observed_at.isoformat(),
+            str(observed_price.value),
+        )
+        return cls(
+            trigger_event_id=event_id,
+            signal_id=signal_id,
+            instrument_id=instrument_id,
+            reference_price=reference_price,
+            observed_price=observed_price,
+            observed_at=observed_at,
+            run=run,
+        )
+
+    def expected_id(self) -> TriggerEventId:
+        return deterministic_id(
+            TriggerEventId,
+            str(self.run.run_id),
+            str(self.signal_id),
+            self.observed_at.isoformat(),
+            str(self.observed_price.value),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EntryIntent:
+    """Immutable request to execute an entry after a trigger event."""
+
+    entry_intent_id: EntryIntentId
+    trigger_event_id: TriggerEventId
+    signal_id: SignalId
+    instrument_id: InstrumentId
+    reference_price: Price
+    quantity: Quantity
+    execution_mode: ExecutionMode
+    created_at: datetime
+    run: RunIdentity
+
+    def __post_init__(self) -> None:
+        require_aware(self.created_at)
+        if self.reference_price.value <= 0:
+            raise ValueError("EntryIntent reference_price must be strictly positive")
+        if self.entry_intent_id != self.expected_id():
+            raise ValueError("EntryIntent ID does not match deterministic logical identity")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        trigger_event_id: TriggerEventId,
+        signal_id: SignalId,
+        instrument_id: InstrumentId,
+        reference_price: Price,
+        quantity: Quantity,
+        execution_mode: ExecutionMode,
+        created_at: datetime,
+        run: RunIdentity,
+    ) -> EntryIntent:
+        intent_id = deterministic_id(
+            EntryIntentId,
+            str(run.run_id),
+            str(trigger_event_id),
+            str(instrument_id),
+            str(quantity.value),
+            execution_mode.value,
+        )
+        return cls(
+            entry_intent_id=intent_id,
+            trigger_event_id=trigger_event_id,
+            signal_id=signal_id,
+            instrument_id=instrument_id,
+            reference_price=reference_price,
+            quantity=quantity,
+            execution_mode=execution_mode,
+            created_at=created_at,
+            run=run,
+        )
+
+    def expected_id(self) -> EntryIntentId:
+        return deterministic_id(
+            EntryIntentId,
+            str(self.run.run_id),
+            str(self.trigger_event_id),
+            str(self.instrument_id),
+            str(self.quantity.value),
+            self.execution_mode.value,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Fill:
+    """Immutable actual execution fact distinct from trigger/reference price."""
+
+    fill_id: FillId
+    entry_intent_id: EntryIntentId
+    trigger_event_id: TriggerEventId
+    signal_id: SignalId
+    instrument_id: InstrumentId
+    reference_price: Price
+    fill_price: Price
+    quantity: Quantity
+    execution_mode: ExecutionMode
+    filled_at: datetime
+    run: RunIdentity
+
+    def __post_init__(self) -> None:
+        require_aware(self.filled_at)
+        if self.reference_price.value <= 0 or self.fill_price.value <= 0:
+            raise ValueError("Fill prices must be strictly positive")
+        if self.fill_id != self.expected_id():
+            raise ValueError("Fill ID does not match deterministic logical identity")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        entry_intent_id: EntryIntentId,
+        trigger_event_id: TriggerEventId,
+        signal_id: SignalId,
+        instrument_id: InstrumentId,
+        reference_price: Price,
+        fill_price: Price,
+        quantity: Quantity,
+        execution_mode: ExecutionMode,
+        filled_at: datetime,
+        run: RunIdentity,
+    ) -> Fill:
+        fill_id = deterministic_id(
+            FillId,
+            str(run.run_id),
+            str(entry_intent_id),
+            filled_at.isoformat(),
+            str(fill_price.value),
+            str(quantity.value),
+        )
+        return cls(
+            fill_id=fill_id,
+            entry_intent_id=entry_intent_id,
+            trigger_event_id=trigger_event_id,
+            signal_id=signal_id,
+            instrument_id=instrument_id,
+            reference_price=reference_price,
+            fill_price=fill_price,
+            quantity=quantity,
+            execution_mode=execution_mode,
+            filled_at=filled_at,
+            run=run,
+        )
+
+    def expected_id(self) -> FillId:
+        return deterministic_id(
+            FillId,
+            str(self.run.run_id),
+            str(self.entry_intent_id),
+            self.filled_at.isoformat(),
+            str(self.fill_price.value),
+            str(self.quantity.value),
+        )

--- a/signalforge/domain/ids.py
+++ b/signalforge/domain/ids.py
@@ -41,6 +41,11 @@ class TriggerEventId(_IdBase):
 
 
 @dataclass(frozen=True, slots=True)
+class EntryIntentId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
 class FillId(_IdBase):
     pass
 

--- a/tests/unit/domain/test_execution.py
+++ b/tests/unit/domain/test_execution.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, TriggerEvent
+from signalforge.domain.ids import ConfigId, InstrumentId, RunId, SignalId
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-001"),
+        config_hash="abc123",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _trigger() -> TriggerEvent:
+    return TriggerEvent.create(
+        signal_id=SignalId("signal-001"),
+        instrument_id=InstrumentId("NSE:RELIANCE"),
+        reference_price=Price(Decimal("1383.15")),
+        observed_price=Price(Decimal("1383.20")),
+        observed_at=datetime(2026, 8, 28, 10, 7, tzinfo=IST),
+        run=_run(),
+    )
+
+
+def _intent(trigger: TriggerEvent) -> EntryIntent:
+    return EntryIntent.create(
+        trigger_event_id=trigger.trigger_event_id,
+        signal_id=trigger.signal_id,
+        instrument_id=trigger.instrument_id,
+        reference_price=trigger.reference_price,
+        quantity=Quantity(10),
+        execution_mode=ExecutionMode.PAPER,
+        created_at=datetime(2026, 8, 28, 10, 7, 1, tzinfo=IST),
+        run=trigger.run,
+    )
+
+
+def test_trigger_event_is_immutable_and_does_not_imply_trade() -> None:
+    trigger = _trigger()
+
+    assert trigger.observed_price == Price(Decimal("1383.20"))
+    assert "trade_id" not in TriggerEvent.__dataclass_fields__
+    assert "position_id" not in TriggerEvent.__dataclass_fields__
+
+    with pytest.raises(FrozenInstanceError):
+        trigger.observed_price = Price(Decimal("1384"))  # type: ignore[misc]
+
+
+def test_trigger_event_requires_observed_price_at_or_above_reference() -> None:
+    with pytest.raises(ValueError, match="meet or exceed"):
+        TriggerEvent.create(
+            signal_id=SignalId("signal-001"),
+            instrument_id=InstrumentId("NSE:RELIANCE"),
+            reference_price=Price(Decimal("1383.15")),
+            observed_price=Price(Decimal("1383.10")),
+            observed_at=datetime(2026, 8, 28, 10, 7, tzinfo=IST),
+            run=_run(),
+        )
+
+
+def test_trigger_identity_is_deterministic() -> None:
+    assert _trigger().trigger_event_id == _trigger().trigger_event_id
+
+
+def test_entry_intent_is_distinct_immutable_execution_request() -> None:
+    trigger = _trigger()
+    intent = _intent(trigger)
+
+    assert intent.trigger_event_id == trigger.trigger_event_id
+    assert intent.quantity == Quantity(10)
+    assert intent.execution_mode is ExecutionMode.PAPER
+    assert "fill_price" not in EntryIntent.__dataclass_fields__
+
+    with pytest.raises(FrozenInstanceError):
+        intent.quantity = Quantity(20)  # type: ignore[misc]
+
+
+def test_fill_retains_actual_price_separately_from_reference_price() -> None:
+    trigger = _trigger()
+    intent = _intent(trigger)
+    fill = Fill.create(
+        entry_intent_id=intent.entry_intent_id,
+        trigger_event_id=trigger.trigger_event_id,
+        signal_id=trigger.signal_id,
+        instrument_id=trigger.instrument_id,
+        reference_price=intent.reference_price,
+        fill_price=Price(Decimal("1383.35")),
+        quantity=intent.quantity,
+        execution_mode=intent.execution_mode,
+        filled_at=datetime(2026, 8, 28, 10, 7, 2, tzinfo=IST),
+        run=intent.run,
+    )
+
+    assert fill.reference_price == Price(Decimal("1383.15"))
+    assert fill.fill_price == Price(Decimal("1383.35"))
+    assert fill.fill_price != fill.reference_price
+    assert fill.quantity == Quantity(10)
+
+
+def test_fill_identity_changes_with_actual_execution_fact() -> None:
+    trigger = _trigger()
+    intent = _intent(trigger)
+    common = {
+        "entry_intent_id": intent.entry_intent_id,
+        "trigger_event_id": trigger.trigger_event_id,
+        "signal_id": trigger.signal_id,
+        "instrument_id": trigger.instrument_id,
+        "reference_price": intent.reference_price,
+        "quantity": intent.quantity,
+        "execution_mode": intent.execution_mode,
+        "filled_at": datetime(2026, 8, 28, 10, 7, 2, tzinfo=IST),
+        "run": intent.run,
+    }
+    first = Fill.create(fill_price=Price(Decimal("1383.30")), **common)
+    second = Fill.create(fill_price=Price(Decimal("1383.35")), **common)
+
+    assert first.fill_id != second.fill_id
+
+
+def test_execution_timestamps_must_be_timezone_aware() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        TriggerEvent.create(
+            signal_id=SignalId("signal-001"),
+            instrument_id=InstrumentId("NSE:RELIANCE"),
+            reference_price=Price(Decimal("1383.15")),
+            observed_price=Price(Decimal("1383.20")),
+            observed_at=datetime(2026, 8, 28, 10, 7),
+            run=_run(),
+        )
+
+
+def test_domain_execution_mode_is_broker_independent() -> None:
+    assert tuple(ExecutionMode) == (ExecutionMode.PAPER, ExecutionMode.LIVE)


### PR DESCRIPTION
## What changed
Implements SF-013 TriggerEvent, EntryIntent, and Fill as distinct immutable broker-neutral domain facts.

- Adds strongly typed `EntryIntentId`
- Adds `TriggerEvent` for observed trigger occurrence
- Adds `EntryIntent` for an execution request
- Adds `Fill` for actual execution evidence
- Preserves trigger/reference price separately from actual fill price
- Preserves quantity, execution mode, timestamps, instrument, signal, trigger, and run provenance
- Uses deterministic IDs for trigger events, entry intents, and fills
- Keeps TriggerEvent independent of Trade/Position state
- Keeps execution modes domain-level (`paper`, `live`) with no broker SDK types
- Adds unit tests for immutability, deterministic identity, trigger-price constraints, actual fill-price separation, timestamp safety, and domain boundaries

## Scope boundary
No Trade, Position, exit, order-routing, or broker adapter behavior is implemented here.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002/ADR-007 execution-domain boundaries. No strategy semantic changes.

Relates to #14.