### PR TITLE
SF-014 — Add Trade state machine

### DIFF
--- a/signalforge/domain/trades.py
+++ b/signalforge/domain/trades.py
@@ -1,0 +1,126 @@
+"""Trade economic lifecycle and immutable entry economics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+
+from signalforge.domain.execution import Fill
+from signalforge.domain.ids import ExitId, FillId, InstrumentId, SignalId, TradeId, deterministic_id
+from signalforge.domain.money import Price, Quantity, ceil_to_tick
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.states import InvalidStateTransition
+from signalforge.domain.time import require_aware
+
+
+class TradeState(StrEnum):
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True, eq=False, slots=True)
+class Trade:
+    """Controlled trade lifecycle with economics frozen from the accepted entry fill."""
+
+    trade_id: TradeId
+    entry_fill_id: FillId
+    signal_id: SignalId
+    instrument_id: InstrumentId
+    entry_price: Price
+    stop_price: Price
+    raw_target_price: Price
+    tradable_target_price: Price
+    risk_per_share: Price
+    quantity: Quantity
+    opened_at: datetime
+    run: RunIdentity
+    state: TradeState = TradeState.OPEN
+    closed_at: datetime | None = None
+    exit_id: ExitId | None = None
+
+    def __post_init__(self) -> None:
+        require_aware(self.opened_at)
+        if self.entry_price.value <= 0 or self.stop_price.value <= 0:
+            raise ValueError("Trade entry and stop prices must be strictly positive")
+        expected_risk = self.entry_price.value - self.stop_price.value
+        if expected_risk <= 0:
+            raise ValueError("Trade risk_per_share must be strictly positive before OPEN")
+        if self.risk_per_share.value != expected_risk:
+            raise ValueError("Trade risk_per_share must equal actual fill minus stop")
+        expected_raw_target = self.entry_price.value + Decimal("1.5") * expected_risk
+        if self.raw_target_price.value != expected_raw_target:
+            raise ValueError("Trade raw target must equal entry plus 1.5R")
+        if self.tradable_target_price.value < self.raw_target_price.value:
+            raise ValueError("Trade tradable target must not be below raw target")
+        if self.trade_id != self.expected_id():
+            raise ValueError("Trade ID does not match deterministic logical identity")
+        self._validate_state_metadata()
+
+    @classmethod
+    def open_from_fill(
+        cls,
+        *,
+        entry_fill: Fill,
+        stop_price: Price,
+        target_tick_size: Price,
+    ) -> Trade:
+        """Open a trade from an accepted entry fill using actual-fill economics."""
+
+        risk_value = entry_fill.fill_price.value - stop_price.value
+        if risk_value <= 0:
+            raise ValueError("Trade risk_per_share must be strictly positive before OPEN")
+        risk = Price(risk_value)
+        raw_target = Price(entry_fill.fill_price.value + Decimal("1.5") * risk_value)
+        tradable_target = ceil_to_tick(raw_target, target_tick_size)
+        trade_id = deterministic_id(
+            TradeId,
+            str(entry_fill.run.run_id),
+            str(entry_fill.fill_id),
+        )
+        return cls(
+            trade_id=trade_id,
+            entry_fill_id=entry_fill.fill_id,
+            signal_id=entry_fill.signal_id,
+            instrument_id=entry_fill.instrument_id,
+            entry_price=entry_fill.fill_price,
+            stop_price=stop_price,
+            raw_target_price=raw_target,
+            tradable_target_price=tradable_target,
+            risk_per_share=risk,
+            quantity=entry_fill.quantity,
+            opened_at=entry_fill.filled_at,
+            run=entry_fill.run,
+        )
+
+    def close(self, *, exit_id: ExitId, at: datetime) -> None:
+        """Close an OPEN trade exactly once using an immutable exit reference."""
+
+        if self.state is not TradeState.OPEN:
+            raise InvalidStateTransition(f"Cannot close Trade from state {self.state.value}")
+        require_aware(at)
+        if at < self.opened_at:
+            raise ValueError("Trade close timestamp must not precede open timestamp")
+        object.__setattr__(self, "state", TradeState.CLOSED)
+        object.__setattr__(self, "closed_at", at)
+        object.__setattr__(self, "exit_id", exit_id)
+
+    def expected_id(self) -> TradeId:
+        return deterministic_id(
+            TradeId,
+            str(self.run.run_id),
+            str(self.entry_fill_id),
+        )
+
+    def _validate_state_metadata(self) -> None:
+        if self.closed_at is not None:
+            require_aware(self.closed_at)
+            if self.closed_at < self.opened_at:
+                raise ValueError("Trade close timestamp must not precede open timestamp")
+        if self.state is TradeState.OPEN:
+            if self.closed_at is not None or self.exit_id is not None:
+                raise ValueError("OPEN trade cannot have close metadata")
+        elif self.state is TradeState.CLOSED:
+            if self.closed_at is None or self.exit_id is None:
+                raise ValueError("CLOSED trade requires closed_at and exit_id")

--- a/tests/unit/domain/test_trades.py
+++ b/tests/unit/domain/test_trades.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.execution import ExecutionMode, Fill
+from signalforge.domain.ids import (
+    ConfigId,
+    EntryIntentId,
+    ExitId,
+    FillId,
+    InstrumentId,
+    RunId,
+    SignalId,
+    TriggerEventId,
+)
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.states import InvalidStateTransition
+from signalforge.domain.trades import Trade, TradeState
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-001"),
+        config_hash="abc123",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _fill(*, fill_price: str = "1383.35", quantity: int = 10) -> Fill:
+    return Fill.create(
+        entry_intent_id=EntryIntentId("intent-001"),
+        trigger_event_id=TriggerEventId("trigger-001"),
+        signal_id=SignalId("signal-001"),
+        instrument_id=InstrumentId("NSE:RELIANCE"),
+        reference_price=Price(Decimal("1383.15")),
+        fill_price=Price(Decimal(fill_price)),
+        quantity=Quantity(quantity),
+        execution_mode=ExecutionMode.PAPER,
+        filled_at=datetime(2026, 8, 28, 10, 7, 2, tzinfo=IST),
+        run=_run(),
+    )
+
+
+def _trade() -> Trade:
+    return Trade.open_from_fill(
+        entry_fill=_fill(),
+        stop_price=Price(Decimal("1379.50")),
+        target_tick_size=Price(Decimal("0.05")),
+    )
+
+
+def test_trade_opens_from_actual_fill_with_frozen_economics() -> None:
+    trade = _trade()
+
+    assert trade.state is TradeState.OPEN
+    assert trade.entry_price == Price(Decimal("1383.35"))
+    assert trade.stop_price == Price(Decimal("1379.50"))
+    assert trade.risk_per_share == Price(Decimal("3.85"))
+    assert trade.raw_target_price == Price(Decimal("1389.125"))
+    assert trade.tradable_target_price == Price(Decimal("1389.15"))
+    assert trade.quantity == Quantity(10)
+
+    with pytest.raises(FrozenInstanceError):
+        trade.stop_price = Price(Decimal("1380"))  # type: ignore[misc]
+
+
+def test_trade_risk_uses_actual_fill_not_reference_price() -> None:
+    trade = Trade.open_from_fill(
+        entry_fill=_fill(fill_price="1383.35"),
+        stop_price=Price(Decimal("1380.00")),
+        target_tick_size=Price(Decimal("0.05")),
+    )
+
+    assert trade.entry_price == Price(Decimal("1383.35"))
+    assert trade.risk_per_share == Price(Decimal("3.35"))
+    assert trade.raw_target_price == Price(Decimal("1388.375"))
+    assert trade.tradable_target_price == Price(Decimal("1388.40"))
+
+
+def test_trade_rejects_zero_or_negative_risk_before_open() -> None:
+    with pytest.raises(ValueError, match="strictly positive before OPEN"):
+        Trade.open_from_fill(
+            entry_fill=_fill(fill_price="1383.35"),
+            stop_price=Price(Decimal("1383.35")),
+            target_tick_size=Price(Decimal("0.05")),
+        )
+
+    with pytest.raises(ValueError, match="strictly positive before OPEN"):
+        Trade.open_from_fill(
+            entry_fill=_fill(fill_price="1383.35"),
+            stop_price=Price(Decimal("1384.00")),
+            target_tick_size=Price(Decimal("0.05")),
+        )
+
+
+def test_trade_identity_is_deterministic_from_run_and_entry_fill() -> None:
+    first = _trade()
+    second = _trade()
+
+    assert first.trade_id == second.trade_id
+
+
+def test_trade_closes_once_and_cannot_reopen_or_reclose() -> None:
+    trade = _trade()
+    exit_id = ExitId("exit-001")
+    closed_at = datetime(2026, 8, 28, 11, 0, tzinfo=IST)
+
+    trade.close(exit_id=exit_id, at=closed_at)
+
+    assert trade.state is TradeState.CLOSED
+    assert trade.closed_at == closed_at
+    assert trade.exit_id == exit_id
+
+    with pytest.raises(InvalidStateTransition):
+        trade.close(exit_id=ExitId("exit-002"), at=closed_at)
+
+    with pytest.raises(FrozenInstanceError):
+        trade.state = TradeState.OPEN  # type: ignore[misc]
+
+
+def test_trade_close_timestamp_must_be_timezone_aware_and_not_precede_open() -> None:
+    trade = _trade()
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        trade.close(exit_id=ExitId("exit-001"), at=datetime(2026, 8, 28, 11, 0))
+
+    with pytest.raises(ValueError, match="must not precede"):
+        trade.close(
+            exit_id=ExitId("exit-001"),
+            at=datetime(2026, 8, 28, 10, 0, tzinfo=IST),
+        )
+
+
+def test_trade_reconstruction_requires_consistent_economics() -> None:
+    valid = _trade()
+
+    with pytest.raises(ValueError, match="risk_per_share must equal"):
+        Trade(
+            trade_id=valid.trade_id,
+            entry_fill_id=valid.entry_fill_id,
+            signal_id=valid.signal_id,
+            instrument_id=valid.instrument_id,
+            entry_price=valid.entry_price,
+            stop_price=valid.stop_price,
+            raw_target_price=valid.raw_target_price,
+            tradable_target_price=valid.tradable_target_price,
+            risk_per_share=Price(Decimal("1.00")),
+            quantity=valid.quantity,
+            opened_at=valid.opened_at,
+            run=valid.run,
+        )
+
+
+def test_closed_trade_reconstruction_requires_exit_metadata() -> None:
+    valid = _trade()
+
+    with pytest.raises(ValueError, match="CLOSED trade requires"):
+        Trade(
+            trade_id=valid.trade_id,
+            entry_fill_id=valid.entry_fill_id,
+            signal_id=valid.signal_id,
+            instrument_id=valid.instrument_id,
+            entry_price=valid.entry_price,
+            stop_price=valid.stop_price,
+            raw_target_price=valid.raw_target_price,
+            tradable_target_price=valid.tradable_target_price,
+            risk_per_share=valid.risk_per_share,
+            quantity=valid.quantity,
+            opened_at=valid.opened_at,
+            run=valid.run,
+            state=TradeState.CLOSED,
+        )
+
+
+def test_trade_has_stable_object_identity_while_state_changes() -> None:
+    trade = _trade()
+    original_hash = hash(trade)
+
+    trade.close(
+        exit_id=ExitId("exit-001"),
+        at=datetime(2026, 8, 28, 11, 0, tzinfo=IST),
+    )
+
+    assert hash(trade) == original_hash
+
+
+def test_fill_reference_is_retained() -> None:
+    fill = _fill()
+    trade = Trade.open_from_fill(
+        entry_fill=fill,
+        stop_price=Price(Decimal("1379.50")),
+        target_tick_size=Price(Decimal("0.05")),
+    )
+
+    assert trade.entry_fill_id == fill.fill_id
+    assert isinstance(trade.entry_fill_id, FillId)


### PR DESCRIPTION
## What changed
Implements SF-014 Trade as the economic lifecycle entity.

- Adds `TradeState`: OPEN and CLOSED
- Opens Trade only from an accepted immutable entry `Fill`
- Persists entry fill reference, signal/instrument/run provenance, actual entry price, stop, quantity, risk per share, raw target and tradable target
- Calculates `risk_per_share = actual fill - stop` and rejects zero/negative risk before OPEN
- Calculates raw target as entry + 1.5R
- Normalizes executable target upward to the supplied valid tick size
- Freezes entry, stop, target, risk and quantity economics once OPEN
- Allows only OPEN -> CLOSED with timezone-aware close timestamp and ExitId reference
- Prevents re-close/reopen through specific `InvalidStateTransition` behavior and frozen external mutation
- Uses stable object identity while controlled lifecycle state changes internally
- Adds unit tests for actual-fill economics, tick normalization, invalid risk, immutable economics, deterministic trade identity, close semantics and reconstruction invariants

## Scope boundary
Exit economics/fill details remain for the later Exit domain issue. Position state is not implemented here.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002 trade lifecycle and frozen Strategy V1 economic invariants. No strategy semantic changes.

Relates to #15.