### PR TITLE
SF-015 — Add Position state machine

### DIFF
--- a/signalforge/domain/positions.py
+++ b/signalforge/domain/positions.py
@@ -1,0 +1,93 @@
+"""Position exposure lifecycle distinct from Trade economics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from signalforge.domain.ids import InstrumentId, PositionId, TradeId, deterministic_id
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.states import InvalidStateTransition
+from signalforge.domain.time import require_aware
+from signalforge.domain.trades import Trade, TradeState
+
+
+class PositionState(StrEnum):
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True, eq=False, slots=True)
+class Position:
+    """Controlled exposure lifecycle for the MVP's one-trade/one-position model."""
+
+    position_id: PositionId
+    trade_id: TradeId
+    instrument_id: InstrumentId
+    quantity: Quantity
+    average_entry_price: Price
+    opened_at: datetime
+    run: RunIdentity
+    state: PositionState = PositionState.OPEN
+    closed_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        require_aware(self.opened_at)
+        if self.average_entry_price.value <= 0:
+            raise ValueError("Position average_entry_price must be strictly positive")
+        if self.position_id != self.expected_id():
+            raise ValueError("Position ID does not match deterministic logical identity")
+        self._validate_state_metadata()
+
+    @classmethod
+    def open_from_trade(cls, *, trade: Trade) -> Position:
+        """Open the single MVP Position corresponding to an OPEN Trade."""
+
+        if trade.state is not TradeState.OPEN:
+            raise InvalidStateTransition("Cannot open Position from a non-OPEN Trade")
+        position_id = deterministic_id(
+            PositionId,
+            str(trade.run.run_id),
+            str(trade.trade_id),
+        )
+        return cls(
+            position_id=position_id,
+            trade_id=trade.trade_id,
+            instrument_id=trade.instrument_id,
+            quantity=trade.quantity,
+            average_entry_price=trade.entry_price,
+            opened_at=trade.opened_at,
+            run=trade.run,
+        )
+
+    def close(self, *, at: datetime) -> None:
+        """Close an OPEN Position exactly once."""
+
+        if self.state is not PositionState.OPEN:
+            raise InvalidStateTransition(f"Cannot close Position from state {self.state.value}")
+        require_aware(at)
+        if at < self.opened_at:
+            raise ValueError("Position close timestamp must not precede open timestamp")
+        object.__setattr__(self, "state", PositionState.CLOSED)
+        object.__setattr__(self, "closed_at", at)
+
+    def expected_id(self) -> PositionId:
+        return deterministic_id(
+            PositionId,
+            str(self.run.run_id),
+            str(self.trade_id),
+        )
+
+    def _validate_state_metadata(self) -> None:
+        if self.closed_at is not None:
+            require_aware(self.closed_at)
+            if self.closed_at < self.opened_at:
+                raise ValueError("Position close timestamp must not precede open timestamp")
+        if self.state is PositionState.OPEN:
+            if self.closed_at is not None:
+                raise ValueError("OPEN Position cannot have closed_at")
+        elif self.state is PositionState.CLOSED:
+            if self.closed_at is None:
+                raise ValueError("CLOSED Position requires closed_at")

--- a/tests/unit/domain/test_positions.py
+++ b/tests/unit/domain/test_positions.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.execution import ExecutionMode, Fill
+from signalforge.domain.ids import (
+    ConfigId,
+    EntryIntentId,
+    ExitId,
+    InstrumentId,
+    RunId,
+    SignalId,
+    TriggerEventId,
+)
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.positions import Position, PositionState
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.states import InvalidStateTransition
+from signalforge.domain.trades import Trade
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-001"),
+        config_hash="abc123",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _trade() -> Trade:
+    fill = Fill.create(
+        entry_intent_id=EntryIntentId("intent-001"),
+        trigger_event_id=TriggerEventId("trigger-001"),
+        signal_id=SignalId("signal-001"),
+        instrument_id=InstrumentId("NSE:RELIANCE"),
+        reference_price=Price(Decimal("1383.15")),
+        fill_price=Price(Decimal("1383.35")),
+        quantity=Quantity(10),
+        execution_mode=ExecutionMode.PAPER,
+        filled_at=datetime(2026, 8, 28, 10, 7, 2, tzinfo=IST),
+        run=_run(),
+    )
+    return Trade.open_from_fill(
+        entry_fill=fill,
+        stop_price=Price(Decimal("1379.50")),
+        target_tick_size=Price(Decimal("0.05")),
+    )
+
+
+def _position() -> Position:
+    return Position.open_from_trade(trade=_trade())
+
+
+def test_position_opens_from_trade_as_distinct_exposure_entity() -> None:
+    trade = _trade()
+    position = Position.open_from_trade(trade=trade)
+
+    assert position.state is PositionState.OPEN
+    assert position.trade_id == trade.trade_id
+    assert position.position_id.value != trade.trade_id.value
+    assert position.instrument_id == trade.instrument_id
+    assert position.quantity == trade.quantity
+    assert position.average_entry_price == trade.entry_price
+    assert position.opened_at == trade.opened_at
+
+
+def test_position_identity_is_deterministic_for_one_trade() -> None:
+    trade = _trade()
+
+    first = Position.open_from_trade(trade=trade)
+    second = Position.open_from_trade(trade=trade)
+
+    assert first.position_id == second.position_id
+
+
+def test_position_cannot_open_from_closed_trade() -> None:
+    trade = _trade()
+    trade.close(
+        exit_id=ExitId("exit-001"),
+        at=datetime(2026, 8, 28, 11, 0, tzinfo=IST),
+    )
+
+    with pytest.raises(InvalidStateTransition, match="non-OPEN Trade"):
+        Position.open_from_trade(trade=trade)
+
+
+def test_position_closes_once_and_cannot_reopen_or_reclose() -> None:
+    position = _position()
+    closed_at = datetime(2026, 8, 28, 11, 0, tzinfo=IST)
+
+    position.close(at=closed_at)
+
+    assert position.state is PositionState.CLOSED
+    assert position.closed_at == closed_at
+
+    with pytest.raises(InvalidStateTransition):
+        position.close(at=closed_at)
+
+    with pytest.raises(FrozenInstanceError):
+        position.state = PositionState.OPEN  # type: ignore[misc]
+
+
+def test_position_close_timestamp_must_be_aware_and_not_precede_open() -> None:
+    position = _position()
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        position.close(at=datetime(2026, 8, 28, 11, 0))
+
+    with pytest.raises(ValueError, match="must not precede"):
+        position.close(at=datetime(2026, 8, 28, 10, 0, tzinfo=IST))
+
+
+def test_position_exposure_fields_are_immutable_and_no_scaling_fields_exist() -> None:
+    position = _position()
+
+    with pytest.raises(FrozenInstanceError):
+        position.quantity = Quantity(20)  # type: ignore[misc]
+
+    with pytest.raises(FrozenInstanceError):
+        position.average_entry_price = Price(Decimal("1384"))  # type: ignore[misc]
+
+    field_names = set(Position.__dataclass_fields__)
+    assert "remaining_quantity" not in field_names
+    assert "partial_exit_quantity" not in field_names
+    assert "scale_count" not in field_names
+
+
+def test_position_reconstruction_requires_consistent_state_metadata() -> None:
+    valid = _position()
+
+    with pytest.raises(ValueError, match="CLOSED Position requires closed_at"):
+        Position(
+            position_id=valid.position_id,
+            trade_id=valid.trade_id,
+            instrument_id=valid.instrument_id,
+            quantity=valid.quantity,
+            average_entry_price=valid.average_entry_price,
+            opened_at=valid.opened_at,
+            run=valid.run,
+            state=PositionState.CLOSED,
+        )
+
+
+def test_position_has_stable_object_identity_while_state_changes() -> None:
+    position = _position()
+    original_hash = hash(position)
+
+    position.close(at=datetime(2026, 8, 28, 11, 0, tzinfo=IST))
+
+    assert hash(position) == original_hash


### PR DESCRIPTION
## What changed
Implements SF-015 Position as a first-class exposure entity distinct from Trade.

- Adds `PositionState`: OPEN and CLOSED
- Opens Position only from an OPEN Trade
- Preserves one Trade ↔ one Position for the MVP through deterministic Position identity from run + trade
- Keeps Position identity distinct from Trade identity/type
- Persists instrument, fixed quantity, average entry price, open timestamp and run provenance
- Allows only OPEN -> CLOSED with timezone-aware close timestamp
- Prevents reopening/reclosing through `InvalidStateTransition`
- Keeps quantity and average entry price immutable; no scaling or partial-exit fields are introduced
- Uses stable object identity while controlled lifecycle state changes internally
- Adds unit tests for 1:1 identity, distinct typing, immutable exposure, legal/illegal transitions, timestamp safety and reconstruction invariants

## Scope boundary
No scaling, averaging, partial exits, Exit economics, or portfolio aggregation is implemented here.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002 Position/Trade separation. No strategy semantic changes.

Relates to #16.