### PR TITLE
SF-016 — Add immutable Exit domain fact

### DIFF
--- a/signalforge/domain/exits.py
+++ b/signalforge/domain/exits.py
@@ -8,7 +8,14 @@ from decimal import Decimal
 from enum import StrEnum
 
 from signalforge.domain.execution import ExecutionMode
-from signalforge.domain.ids import ExitId, FillId, InstrumentId, PositionId, TradeId, deterministic_id
+from signalforge.domain.ids import (
+    ExitId,
+    FillId,
+    InstrumentId,
+    PositionId,
+    TradeId,
+    deterministic_id,
+)
 from signalforge.domain.money import Price, Quantity
 from signalforge.domain.positions import Position, PositionState
 from signalforge.domain.provenance import RunIdentity

--- a/signalforge/domain/exits.py
+++ b/signalforge/domain/exits.py
@@ -1,0 +1,117 @@
+"""Immutable exit facts for closing MVP trades and positions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+
+from signalforge.domain.execution import ExecutionMode
+from signalforge.domain.ids import ExitId, FillId, InstrumentId, PositionId, TradeId, deterministic_id
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.positions import Position, PositionState
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.time import require_aware
+from signalforge.domain.trades import Trade, TradeState
+
+
+class ExitReason(StrEnum):
+    STOP = "stop"
+    TARGET = "target"
+    FORCED_SESSION_EXIT = "forced_session_exit"
+
+
+@dataclass(frozen=True, slots=True)
+class Exit:
+    """Immutable closure fact preserving actual execution separately from theoretical levels."""
+
+    exit_id: ExitId
+    exit_fill_id: FillId
+    trade_id: TradeId
+    position_id: PositionId
+    instrument_id: InstrumentId
+    reason: ExitReason
+    reference_price: Price
+    fill_price: Price
+    quantity: Quantity
+    execution_mode: ExecutionMode
+    exited_at: datetime
+    realised_pnl: Decimal
+    realised_r: Decimal
+    run: RunIdentity
+
+    def __post_init__(self) -> None:
+        require_aware(self.exited_at)
+        if self.reference_price.value <= 0 or self.fill_price.value <= 0:
+            raise ValueError("Exit prices must be strictly positive")
+        if not self.realised_pnl.is_finite() or not self.realised_r.is_finite():
+            raise ValueError("Exit realised values must be finite")
+        if self.exit_id != self.expected_id():
+            raise ValueError("Exit ID does not match deterministic logical identity")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        trade: Trade,
+        position: Position,
+        exit_fill_id: FillId,
+        reason: ExitReason,
+        reference_price: Price,
+        fill_price: Price,
+        quantity: Quantity,
+        execution_mode: ExecutionMode,
+        exited_at: datetime,
+    ) -> Exit:
+        """Create one full-quantity immutable Exit from an OPEN Trade and Position."""
+
+        if trade.state is not TradeState.OPEN:
+            raise ValueError("Exit requires an OPEN Trade")
+        if position.state is not PositionState.OPEN:
+            raise ValueError("Exit requires an OPEN Position")
+        if position.trade_id != trade.trade_id:
+            raise ValueError("Exit Position must belong to the Trade being closed")
+        if position.instrument_id != trade.instrument_id:
+            raise ValueError("Exit Trade and Position instrument must match")
+        if position.run != trade.run:
+            raise ValueError("Exit Trade and Position run provenance must match")
+        if quantity != trade.quantity or quantity != position.quantity:
+            raise ValueError("Exit quantity must match the full open quantity")
+        require_aware(exited_at)
+        if exited_at < trade.opened_at or exited_at < position.opened_at:
+            raise ValueError("Exit timestamp must not precede Trade/Position open timestamp")
+        if reference_price.value <= 0 or fill_price.value <= 0:
+            raise ValueError("Exit prices must be strictly positive")
+
+        pnl_per_share = fill_price.value - trade.entry_price.value
+        realised_pnl = pnl_per_share * Decimal(quantity.value)
+        realised_r = pnl_per_share / trade.risk_per_share.value
+        exit_id = deterministic_id(
+            ExitId,
+            str(trade.run.run_id),
+            str(trade.trade_id),
+        )
+        return cls(
+            exit_id=exit_id,
+            exit_fill_id=exit_fill_id,
+            trade_id=trade.trade_id,
+            position_id=position.position_id,
+            instrument_id=trade.instrument_id,
+            reason=reason,
+            reference_price=reference_price,
+            fill_price=fill_price,
+            quantity=quantity,
+            execution_mode=execution_mode,
+            exited_at=exited_at,
+            realised_pnl=realised_pnl,
+            realised_r=realised_r,
+            run=trade.run,
+        )
+
+    def expected_id(self) -> ExitId:
+        return deterministic_id(
+            ExitId,
+            str(self.run.run_id),
+            str(self.trade_id),
+        )

--- a/tests/unit/domain/test_exits.py
+++ b/tests/unit/domain/test_exits.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.execution import ExecutionMode, Fill
+from signalforge.domain.exits import Exit, ExitReason
+from signalforge.domain.ids import (
+    ConfigId,
+    EntryIntentId,
+    FillId,
+    InstrumentId,
+    RunId,
+    SignalId,
+    TriggerEventId,
+)
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.positions import Position
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.trades import Trade
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-001"),
+        config_hash="abc123",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _trade_and_position() -> tuple[Trade, Position]:
+    fill = Fill.create(
+        entry_intent_id=EntryIntentId("intent-001"),
+        trigger_event_id=TriggerEventId("trigger-001"),
+        signal_id=SignalId("signal-001"),
+        instrument_id=InstrumentId("NSE:RELIANCE"),
+        reference_price=Price(Decimal("1383.15")),
+        fill_price=Price(Decimal("1383.35")),
+        quantity=Quantity(10),
+        execution_mode=ExecutionMode.PAPER,
+        filled_at=datetime(2026, 8, 28, 10, 7, 2, tzinfo=IST),
+        run=_run(),
+    )
+    trade = Trade.open_from_fill(
+        entry_fill=fill,
+        stop_price=Price(Decimal("1379.50")),
+        target_tick_size=Price(Decimal("0.05")),
+    )
+    return trade, Position.open_from_trade(trade=trade)
+
+
+def _exit(*, reason: ExitReason = ExitReason.TARGET, fill_price: str = "1389.20") -> Exit:
+    trade, position = _trade_and_position()
+    return Exit.create(
+        trade=trade,
+        position=position,
+        exit_fill_id=FillId("exit-fill-001"),
+        reason=reason,
+        reference_price=trade.tradable_target_price,
+        fill_price=Price(Decimal(fill_price)),
+        quantity=trade.quantity,
+        execution_mode=ExecutionMode.PAPER,
+        exited_at=datetime(2026, 8, 28, 11, 0, tzinfo=IST),
+    )
+
+
+def test_exit_is_immutable_and_preserves_actual_fill_separately() -> None:
+    exit_fact = _exit()
+
+    assert exit_fact.reason is ExitReason.TARGET
+    assert exit_fact.reference_price == Price(Decimal("1389.15"))
+    assert exit_fact.fill_price == Price(Decimal("1389.20"))
+    assert exit_fact.fill_price != exit_fact.reference_price
+
+    with pytest.raises(FrozenInstanceError):
+        exit_fact.fill_price = Price(Decimal("1390"))  # type: ignore[misc]
+
+
+def test_exit_calculates_realised_pnl_and_r_from_actual_fill() -> None:
+    exit_fact = _exit(fill_price="1389.20")
+
+    assert exit_fact.realised_pnl == Decimal("58.50")
+    assert exit_fact.realised_r == Decimal("5.85") / Decimal("3.85")
+
+
+def test_stop_exit_can_record_gap_below_theoretical_stop() -> None:
+    trade, position = _trade_and_position()
+    exit_fact = Exit.create(
+        trade=trade,
+        position=position,
+        exit_fill_id=FillId("exit-fill-001"),
+        reason=ExitReason.STOP,
+        reference_price=trade.stop_price,
+        fill_price=Price(Decimal("1379.20")),
+        quantity=trade.quantity,
+        execution_mode=ExecutionMode.PAPER,
+        exited_at=datetime(2026, 8, 28, 10, 30, tzinfo=IST),
+    )
+
+    assert exit_fact.reference_price == Price(Decimal("1379.50"))
+    assert exit_fact.fill_price == Price(Decimal("1379.20"))
+    assert exit_fact.realised_pnl == Decimal("-41.50")
+
+
+def test_exit_requires_full_mvp_quantity() -> None:
+    trade, position = _trade_and_position()
+
+    with pytest.raises(ValueError, match="full open quantity"):
+        Exit.create(
+            trade=trade,
+            position=position,
+            exit_fill_id=FillId("exit-fill-001"),
+            reason=ExitReason.TARGET,
+            reference_price=trade.tradable_target_price,
+            fill_price=Price(Decimal("1389.20")),
+            quantity=Quantity(5),
+            execution_mode=ExecutionMode.PAPER,
+            exited_at=datetime(2026, 8, 28, 11, 0, tzinfo=IST),
+        )
+
+
+def test_exit_identity_allows_only_one_logical_exit_per_trade() -> None:
+    first = _exit(reason=ExitReason.TARGET, fill_price="1389.20")
+    second = _exit(reason=ExitReason.FORCED_SESSION_EXIT, fill_price="1385.00")
+
+    assert first.exit_id == second.exit_id
+
+
+def test_exit_requires_open_trade_and_position() -> None:
+    trade, position = _trade_and_position()
+    position.close(at=datetime(2026, 8, 28, 10, 59, tzinfo=IST))
+
+    with pytest.raises(ValueError, match="OPEN Position"):
+        Exit.create(
+            trade=trade,
+            position=position,
+            exit_fill_id=FillId("exit-fill-001"),
+            reason=ExitReason.FORCED_SESSION_EXIT,
+            reference_price=Price(Decimal("1385.00")),
+            fill_price=Price(Decimal("1385.00")),
+            quantity=trade.quantity,
+            execution_mode=ExecutionMode.PAPER,
+            exited_at=datetime(2026, 8, 28, 11, 0, tzinfo=IST),
+        )
+
+
+def test_exit_timestamp_must_be_aware_and_not_precede_open() -> None:
+    trade, position = _trade_and_position()
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        Exit.create(
+            trade=trade,
+            position=position,
+            exit_fill_id=FillId("exit-fill-001"),
+            reason=ExitReason.TARGET,
+            reference_price=trade.tradable_target_price,
+            fill_price=Price(Decimal("1389.20")),
+            quantity=trade.quantity,
+            execution_mode=ExecutionMode.PAPER,
+            exited_at=datetime(2026, 8, 28, 11, 0),
+        )
+
+
+def test_exit_reason_contract_is_exact_for_mvp() -> None:
+    assert tuple(ExitReason) == (
+        ExitReason.STOP,
+        ExitReason.TARGET,
+        ExitReason.FORCED_SESSION_EXIT,
+    )


### PR DESCRIPTION
## What changed
Implements SF-016 Exit as an immutable closure fact for the MVP Trade/Position lifecycle.

- Adds `ExitReason`: STOP, TARGET, FORCED_SESSION_EXIT
- Links each Exit to Trade, Position, instrument, run, and an exit Fill reference
- Preserves theoretical/reference exit price separately from actual fill price
- Enforces full-quantity exit for the MVP
- Calculates realised P&L from actual exit fill versus actual entry fill
- Calculates realised R from actual exit outcome versus frozen Trade risk per share
- Uses deterministic Exit identity from run + Trade, enforcing one logical Exit per Trade
- Requires OPEN Trade and OPEN Position with matching provenance/instrument
- Enforces timezone-aware exit timestamps that do not precede open state
- Keeps Exit immutable and broker-neutral

## Scope boundary
No scaling, partial exits, broker order routing, or lifecycle orchestration is implemented here. Trade/Position closure transitions remain separate domain operations.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002/ADR-007 exit semantics. No strategy semantic changes.

Relates to #17.