### PR TITLE
SF-017 — Add StateTransition audit model

### DIFF
--- a/signalforge/domain/audit.py
+++ b/signalforge/domain/audit.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 
 from signalforge.domain.ids import StateTransitionId, deterministic_id
 from signalforge.domain.provenance import RunIdentity
-from signalforge.domain.time import require_aware
+from signalforge.domain.time import require_aware, to_utc
 
 
 class TransitionEntityType(StrEnum):
@@ -38,6 +38,10 @@ def _validate_transition_fields(
             raise ValueError(f"StateTransition {name} must not be empty")
     if from_state == to_state:
         raise ValueError("StateTransition must change state")
+
+
+def _identity_timestamp(value: datetime) -> str:
+    return to_utc(value).isoformat()
 
 
 @dataclass(frozen=True, slots=True)
@@ -98,7 +102,7 @@ class StateTransition:
             to_state,
             cause_type,
             cause_id,
-            occurred_at.isoformat(),
+            _identity_timestamp(occurred_at),
         )
         return cls(
             transition_id=transition_id,
@@ -122,5 +126,5 @@ class StateTransition:
             self.to_state,
             self.cause_type,
             self.cause_id,
-            self.occurred_at.isoformat(),
+            _identity_timestamp(self.occurred_at),
         )

--- a/signalforge/domain/audit.py
+++ b/signalforge/domain/audit.py
@@ -17,6 +17,29 @@ class TransitionEntityType(StrEnum):
     POSITION = "position"
 
 
+def _validate_transition_fields(
+    *,
+    entity_id: str,
+    from_state: str,
+    to_state: str,
+    cause_type: str,
+    cause_id: str,
+    occurred_at: datetime,
+) -> None:
+    require_aware(occurred_at)
+    for name, value in (
+        ("entity_id", entity_id),
+        ("from_state", from_state),
+        ("to_state", to_state),
+        ("cause_type", cause_type),
+        ("cause_id", cause_id),
+    ):
+        if not value or not value.strip():
+            raise ValueError(f"StateTransition {name} must not be empty")
+    if from_state == to_state:
+        raise ValueError("StateTransition must change state")
+
+
 @dataclass(frozen=True, slots=True)
 class StateTransition:
     """Immutable audit fact for a completed domain state change."""
@@ -32,18 +55,14 @@ class StateTransition:
     run: RunIdentity
 
     def __post_init__(self) -> None:
-        require_aware(self.occurred_at)
-        for name, value in (
-            ("entity_id", self.entity_id),
-            ("from_state", self.from_state),
-            ("to_state", self.to_state),
-            ("cause_type", self.cause_type),
-            ("cause_id", self.cause_id),
-        ):
-            if not value or not value.strip():
-                raise ValueError(f"StateTransition {name} must not be empty")
-        if self.from_state == self.to_state:
-            raise ValueError("StateTransition must change state")
+        _validate_transition_fields(
+            entity_id=self.entity_id,
+            from_state=self.from_state,
+            to_state=self.to_state,
+            cause_type=self.cause_type,
+            cause_id=self.cause_id,
+            occurred_at=self.occurred_at,
+        )
         if self.transition_id != self.expected_id():
             raise ValueError("StateTransition ID does not match deterministic logical identity")
 
@@ -62,6 +81,14 @@ class StateTransition:
     ) -> StateTransition:
         """Create a deterministic audit fact for one logical state change."""
 
+        _validate_transition_fields(
+            entity_id=entity_id,
+            from_state=from_state,
+            to_state=to_state,
+            cause_type=cause_type,
+            cause_id=cause_id,
+            occurred_at=occurred_at,
+        )
         transition_id = deterministic_id(
             StateTransitionId,
             str(run.run_id),

--- a/signalforge/domain/audit.py
+++ b/signalforge/domain/audit.py
@@ -1,0 +1,99 @@
+"""Immutable audit facts for domain lifecycle transitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from signalforge.domain.ids import StateTransitionId, deterministic_id
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.time import require_aware
+
+
+class TransitionEntityType(StrEnum):
+    ARMED_SETUP = "armed_setup"
+    TRADE = "trade"
+    POSITION = "position"
+
+
+@dataclass(frozen=True, slots=True)
+class StateTransition:
+    """Immutable audit fact for a completed domain state change."""
+
+    transition_id: StateTransitionId
+    entity_type: TransitionEntityType
+    entity_id: str
+    from_state: str
+    to_state: str
+    cause_type: str
+    cause_id: str
+    occurred_at: datetime
+    run: RunIdentity
+
+    def __post_init__(self) -> None:
+        require_aware(self.occurred_at)
+        for name, value in (
+            ("entity_id", self.entity_id),
+            ("from_state", self.from_state),
+            ("to_state", self.to_state),
+            ("cause_type", self.cause_type),
+            ("cause_id", self.cause_id),
+        ):
+            if not value or not value.strip():
+                raise ValueError(f"StateTransition {name} must not be empty")
+        if self.from_state == self.to_state:
+            raise ValueError("StateTransition must change state")
+        if self.transition_id != self.expected_id():
+            raise ValueError("StateTransition ID does not match deterministic logical identity")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        entity_type: TransitionEntityType,
+        entity_id: str,
+        from_state: str,
+        to_state: str,
+        cause_type: str,
+        cause_id: str,
+        occurred_at: datetime,
+        run: RunIdentity,
+    ) -> StateTransition:
+        """Create a deterministic audit fact for one logical state change."""
+
+        transition_id = deterministic_id(
+            StateTransitionId,
+            str(run.run_id),
+            entity_type.value,
+            entity_id,
+            from_state,
+            to_state,
+            cause_type,
+            cause_id,
+            occurred_at.isoformat(),
+        )
+        return cls(
+            transition_id=transition_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            from_state=from_state,
+            to_state=to_state,
+            cause_type=cause_type,
+            cause_id=cause_id,
+            occurred_at=occurred_at,
+            run=run,
+        )
+
+    def expected_id(self) -> StateTransitionId:
+        return deterministic_id(
+            StateTransitionId,
+            str(self.run.run_id),
+            self.entity_type.value,
+            self.entity_id,
+            self.from_state,
+            self.to_state,
+            self.cause_type,
+            self.cause_id,
+            self.occurred_at.isoformat(),
+        )

--- a/signalforge/domain/ids.py
+++ b/signalforge/domain/ids.py
@@ -66,6 +66,11 @@ class ExitId(_IdBase):
 
 
 @dataclass(frozen=True, slots=True)
+class StateTransitionId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
 class InstrumentId(_IdBase):
     pass
 

--- a/tests/unit/domain/test_audit.py
+++ b/tests/unit/domain/test_audit.py
@@ -92,12 +92,13 @@ def test_all_mvp_mutable_entity_types_are_representable() -> None:
         TransitionEntityType.TRADE,
         TransitionEntityType.POSITION,
     ):
+        is_setup = entity_type is TransitionEntityType.ARMED_SETUP
         transition = StateTransition.create(
             entity_type=entity_type,
             entity_id=f"{entity_type.value}-001",
-            from_state="open" if entity_type is not TransitionEntityType.ARMED_SETUP else "armed",
-            to_state="closed" if entity_type is not TransitionEntityType.ARMED_SETUP else "expired",
-            cause_type="exit" if entity_type is not TransitionEntityType.ARMED_SETUP else "market_event",
+            from_state="armed" if is_setup else "open",
+            to_state="expired" if is_setup else "closed",
+            cause_type="market_event" if is_setup else "exit",
             cause_id="cause-001",
             occurred_at=datetime(2026, 8, 28, 11, 0, tzinfo=IST),
             run=_run(),

--- a/tests/unit/domain/test_audit.py
+++ b/tests/unit/domain/test_audit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
-from datetime import datetime
+from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -57,6 +57,24 @@ def test_transition_identity_is_deterministic_for_same_logical_change() -> None:
 
     assert first.transition_id == second.transition_id
     assert isinstance(first.transition_id, StateTransitionId)
+
+
+def test_transition_identity_is_timezone_representation_independent() -> None:
+    ist_transition = _transition()
+    utc_transition = StateTransition.create(
+        entity_type=ist_transition.entity_type,
+        entity_id=ist_transition.entity_id,
+        from_state=ist_transition.from_state,
+        to_state=ist_transition.to_state,
+        cause_type=ist_transition.cause_type,
+        cause_id=ist_transition.cause_id,
+        occurred_at=ist_transition.occurred_at.astimezone(UTC),
+        run=ist_transition.run,
+    )
+
+    assert utc_transition.occurred_at != ist_transition.occurred_at
+    assert utc_transition.occurred_at.timestamp() == ist_transition.occurred_at.timestamp()
+    assert utc_transition.transition_id == ist_transition.transition_id
 
 
 def test_transition_identity_changes_for_different_cause_or_timestamp() -> None:

--- a/tests/unit/domain/test_audit.py
+++ b/tests/unit/domain/test_audit.py
@@ -72,7 +72,8 @@ def test_transition_identity_is_timezone_representation_independent() -> None:
         run=ist_transition.run,
     )
 
-    assert utc_transition.occurred_at != ist_transition.occurred_at
+    assert utc_transition.occurred_at.tzinfo is UTC
+    assert ist_transition.occurred_at.tzinfo is IST
     assert utc_transition.occurred_at.timestamp() == ist_transition.occurred_at.timestamp()
     assert utc_transition.transition_id == ist_transition.transition_id
 

--- a/tests/unit/domain/test_audit.py
+++ b/tests/unit/domain/test_audit.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from signalforge.domain.audit import StateTransition, TransitionEntityType
+from signalforge.domain.ids import ConfigId, RunId, StateTransitionId
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-001"),
+        config_hash="abc123",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _transition() -> StateTransition:
+    return StateTransition.create(
+        entity_type=TransitionEntityType.ARMED_SETUP,
+        entity_id="setup-001",
+        from_state="armed",
+        to_state="triggered",
+        cause_type="trigger_event",
+        cause_id="trigger-001",
+        occurred_at=datetime(2026, 8, 28, 10, 7, 1, tzinfo=IST),
+        run=_run(),
+    )
+
+
+def test_state_transition_is_immutable_and_retains_cause_and_provenance() -> None:
+    transition = _transition()
+
+    assert transition.entity_type is TransitionEntityType.ARMED_SETUP
+    assert transition.entity_id == "setup-001"
+    assert transition.from_state == "armed"
+    assert transition.to_state == "triggered"
+    assert transition.cause_type == "trigger_event"
+    assert transition.cause_id == "trigger-001"
+    assert transition.run == _run()
+
+    with pytest.raises(FrozenInstanceError):
+        transition.to_state = "expired"  # type: ignore[misc]
+
+
+def test_transition_identity_is_deterministic_for_same_logical_change() -> None:
+    first = _transition()
+    second = _transition()
+
+    assert first.transition_id == second.transition_id
+    assert isinstance(first.transition_id, StateTransitionId)
+
+
+def test_transition_identity_changes_for_different_cause_or_timestamp() -> None:
+    base = _transition()
+    different_cause = StateTransition.create(
+        entity_type=base.entity_type,
+        entity_id=base.entity_id,
+        from_state=base.from_state,
+        to_state=base.to_state,
+        cause_type="session_boundary",
+        cause_id="15:05",
+        occurred_at=base.occurred_at,
+        run=base.run,
+    )
+    different_time = StateTransition.create(
+        entity_type=base.entity_type,
+        entity_id=base.entity_id,
+        from_state=base.from_state,
+        to_state=base.to_state,
+        cause_type=base.cause_type,
+        cause_id=base.cause_id,
+        occurred_at=datetime(2026, 8, 28, 10, 7, 2, tzinfo=IST),
+        run=base.run,
+    )
+
+    assert different_cause.transition_id != base.transition_id
+    assert different_time.transition_id != base.transition_id
+
+
+def test_all_mvp_mutable_entity_types_are_representable() -> None:
+    for entity_type in (
+        TransitionEntityType.ARMED_SETUP,
+        TransitionEntityType.TRADE,
+        TransitionEntityType.POSITION,
+    ):
+        transition = StateTransition.create(
+            entity_type=entity_type,
+            entity_id=f"{entity_type.value}-001",
+            from_state="open" if entity_type is not TransitionEntityType.ARMED_SETUP else "armed",
+            to_state="closed" if entity_type is not TransitionEntityType.ARMED_SETUP else "expired",
+            cause_type="exit" if entity_type is not TransitionEntityType.ARMED_SETUP else "market_event",
+            cause_id="cause-001",
+            occurred_at=datetime(2026, 8, 28, 11, 0, tzinfo=IST),
+            run=_run(),
+        )
+
+        assert transition.entity_type is entity_type
+
+
+def test_transition_requires_aware_exchange_timestamp() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        StateTransition.create(
+            entity_type=TransitionEntityType.TRADE,
+            entity_id="trade-001",
+            from_state="open",
+            to_state="closed",
+            cause_type="exit",
+            cause_id="exit-001",
+            occurred_at=datetime(2026, 8, 28, 11, 0),
+            run=_run(),
+        )
+
+
+def test_transition_requires_non_empty_fields_and_actual_state_change() -> None:
+    with pytest.raises(ValueError, match="entity_id"):
+        StateTransition.create(
+            entity_type=TransitionEntityType.POSITION,
+            entity_id=" ",
+            from_state="open",
+            to_state="closed",
+            cause_type="exit",
+            cause_id="exit-001",
+            occurred_at=datetime(2026, 8, 28, 11, 0, tzinfo=IST),
+            run=_run(),
+        )
+
+    with pytest.raises(ValueError, match="must change state"):
+        StateTransition.create(
+            entity_type=TransitionEntityType.TRADE,
+            entity_id="trade-001",
+            from_state="open",
+            to_state="open",
+            cause_type="exit",
+            cause_id="exit-001",
+            occurred_at=datetime(2026, 8, 28, 11, 0, tzinfo=IST),
+            run=_run(),
+        )
+
+
+def test_reconstruction_rejects_non_deterministic_transition_id() -> None:
+    valid = _transition()
+
+    with pytest.raises(ValueError, match="deterministic logical identity"):
+        StateTransition(
+            transition_id=StateTransitionId("wrong-id"),
+            entity_type=valid.entity_type,
+            entity_id=valid.entity_id,
+            from_state=valid.from_state,
+            to_state=valid.to_state,
+            cause_type=valid.cause_type,
+            cause_id=valid.cause_id,
+            occurred_at=valid.occurred_at,
+            run=valid.run,
+        )


### PR DESCRIPTION
## What changed
Implements SF-017 as a small immutable audit fact for domain lifecycle transitions.

- Adds strongly typed `StateTransitionId`
- Adds `TransitionEntityType`: ArmedSetup, Trade, Position
- Captures entity ID, from/to state, cause type/ID, exchange timestamp, and run provenance
- Uses deterministic transition identity from logical transition inputs
- Rejects empty audit fields and no-op state transitions
- Requires timezone-aware transition timestamps
- Keeps audit records immutable
- Keeps current entity state authoritative; no event sourcing or replay engine is introduced
- Adds unit tests covering all mutable MVP entity types, deterministic identity, immutability, cause/provenance retention, timestamp safety, and reconstruction validation

## Scope boundary
This does not orchestrate transitions, mutate domain entities, or introduce an event store. It records completed lifecycle changes for auditability only.

## Tests
CI will run Ruff, mypy, and pytest.

## Architecture impact
Implements ADR-002/ADR-003 auditability requirements without full event sourcing. No strategy semantic changes.

Relates to #18.