### PR TITLE
SF-019 — Add deterministic 5-minute candle engine

### DIFF
--- a/signalforge/runtime/__init__.py
+++ b/signalforge/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic runtime components for SignalForge."""

--- a/signalforge/runtime/candles.py
+++ b/signalforge/runtime/candles.py
@@ -1,0 +1,116 @@
+"""Deterministic five-minute candle aggregation from normalized market events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.market import CandleQuality, CompletedCandle, MarketEvent
+from signalforge.domain.money import Price
+from signalforge.domain.time import CandleInterval, to_ist
+
+
+class LateMarketEvent(ValueError):
+    """Raised when an event belongs to an interval older than the active candle."""
+
+
+@dataclass(slots=True)
+class _ActiveCandle:
+    interval: CandleInterval
+    source: str
+    open: Price
+    high: Price
+    low: Price
+    close: Price
+    volume: int
+    source_event_count: int
+
+    @classmethod
+    def from_event(cls, *, interval: CandleInterval, event: MarketEvent) -> _ActiveCandle:
+        return cls(
+            interval=interval,
+            source=event.source,
+            open=event.price,
+            high=event.price,
+            low=event.price,
+            close=event.price,
+            volume=event.quantity,
+            source_event_count=1,
+        )
+
+    def add(self, event: MarketEvent) -> None:
+        if event.source != self.source:
+            raise ValueError("CandleEngine cannot mix market-event sources within one candle")
+        if event.price.value > self.high.value:
+            self.high = event.price
+        if event.price.value < self.low.value:
+            self.low = event.price
+        self.close = event.price
+        self.volume += event.quantity
+        self.source_event_count += 1
+
+    def complete(self, *, instrument_id: InstrumentId) -> CompletedCandle:
+        return CompletedCandle(
+            instrument_id=instrument_id,
+            interval=self.interval,
+            quality=CandleQuality.VALID,
+            open=self.open,
+            high=self.high,
+            low=self.low,
+            close=self.close,
+            volume=self.volume,
+            source=self.source,
+            source_event_count=self.source_event_count,
+        )
+
+
+def five_minute_interval(exchange_timestamp: datetime) -> CandleInterval:
+    """Return the canonical NSE five-minute interval containing an exchange timestamp."""
+
+    local = to_ist(exchange_timestamp)
+    start = local.replace(minute=(local.minute // 5) * 5, second=0, microsecond=0)
+    return CandleInterval.five_minutes(start)
+
+
+class CandleEngine:
+    """Single-instrument deterministic candle engine for an ordered trade-event stream."""
+
+    def __init__(self, *, instrument_id: InstrumentId) -> None:
+        self._instrument_id = instrument_id
+        self._active: _ActiveCandle | None = None
+        self._last_emitted_end: datetime | None = None
+
+    @property
+    def instrument_id(self) -> InstrumentId:
+        return self._instrument_id
+
+    @property
+    def active_interval(self) -> CandleInterval | None:
+        return self._active.interval if self._active is not None else None
+
+    def process(self, event: MarketEvent) -> CompletedCandle | None:
+        """Apply one event and emit the prior candle if this event closes its interval."""
+
+        if event.instrument_id != self._instrument_id:
+            raise ValueError("CandleEngine received an event for a different instrument")
+
+        interval = five_minute_interval(event.exchange_timestamp)
+
+        if self._active is None:
+            if self._last_emitted_end is not None and interval.start < self._last_emitted_end:
+                raise LateMarketEvent("Market event belongs to an already-emitted interval")
+            self._active = _ActiveCandle.from_event(interval=interval, event=event)
+            return None
+
+        if interval.start < self._active.interval.start:
+            raise LateMarketEvent("Market event is older than the active candle interval")
+
+        if interval.start == self._active.interval.start:
+            self._active.add(event)
+            return None
+
+        completed = self._active.complete(instrument_id=self._instrument_id)
+        self._last_emitted_end = self._active.interval.end
+        self._active = _ActiveCandle.from_event(interval=interval, event=event)
+        return completed

--- a/tests/unit/runtime/test_candles.py
+++ b/tests/unit/runtime/test_candles.py
@@ -11,13 +11,15 @@ from signalforge.domain.money import Price
 from signalforge.domain.time import IST
 from signalforge.runtime.candles import CandleEngine, LateMarketEvent, five_minute_interval
 
+TEST_INSTRUMENT = InstrumentId("NSE:TEST")
+
 
 def _event(
     *,
     at: datetime,
     price: str,
     quantity: int = 1,
-    instrument_id: InstrumentId = InstrumentId("NSE:TEST"),
+    instrument_id: InstrumentId = TEST_INSTRUMENT,
     source: str = "test-feed",
 ) -> MarketEvent:
     return MarketEvent(
@@ -50,20 +52,31 @@ def test_equivalent_utc_and_ist_timestamps_map_to_same_interval() -> None:
 
 
 def test_engine_builds_deterministic_ohlcv_and_emits_on_next_interval() -> None:
-    instrument = InstrumentId("NSE:TEST")
-    engine = CandleEngine(instrument_id=instrument)
+    engine = CandleEngine(instrument_id=TEST_INSTRUMENT)
 
-    assert engine.process(_event(at=datetime(2026, 8, 28, 9, 15, tzinfo=IST), price="100", quantity=2)) is None
-    assert engine.process(_event(at=datetime(2026, 8, 28, 9, 16, tzinfo=IST), price="102", quantity=3)) is None
-    assert engine.process(_event(at=datetime(2026, 8, 28, 9, 18, tzinfo=IST), price="99", quantity=5)) is None
-    assert engine.process(_event(at=datetime(2026, 8, 28, 9, 19, tzinfo=IST), price="101", quantity=7)) is None
+    for minute, price, quantity in (
+        (15, "100", 2),
+        (16, "102", 3),
+        (18, "99", 5),
+        (19, "101", 7),
+    ):
+        assert (
+            engine.process(
+                _event(
+                    at=datetime(2026, 8, 28, 9, minute, tzinfo=IST),
+                    price=price,
+                    quantity=quantity,
+                )
+            )
+            is None
+        )
 
     candle = engine.process(
         _event(at=datetime(2026, 8, 28, 9, 20, tzinfo=IST), price="103", quantity=11)
     )
 
     assert candle is not None
-    assert candle.instrument_id == instrument
+    assert candle.instrument_id == TEST_INSTRUMENT
     assert candle.open == Price(Decimal("100"))
     assert candle.high == Price(Decimal("102"))
     assert candle.low == Price(Decimal("99"))
@@ -74,7 +87,7 @@ def test_engine_builds_deterministic_ohlcv_and_emits_on_next_interval() -> None:
 
 
 def test_gap_does_not_emit_synthetic_empty_candles() -> None:
-    engine = CandleEngine(instrument_id=InstrumentId("NSE:TEST"))
+    engine = CandleEngine(instrument_id=TEST_INSTRUMENT)
     engine.process(_event(at=datetime(2026, 8, 28, 9, 15, tzinfo=IST), price="100"))
 
     first = engine.process(_event(at=datetime(2026, 8, 28, 9, 30, tzinfo=IST), price="105"))
@@ -89,7 +102,7 @@ def test_gap_does_not_emit_synthetic_empty_candles() -> None:
 
 
 def test_engine_rejects_mixed_instruments() -> None:
-    engine = CandleEngine(instrument_id=InstrumentId("NSE:TEST"))
+    engine = CandleEngine(instrument_id=TEST_INSTRUMENT)
 
     with pytest.raises(ValueError, match="different instrument"):
         engine.process(
@@ -102,7 +115,7 @@ def test_engine_rejects_mixed_instruments() -> None:
 
 
 def test_late_event_cannot_mutate_or_reemit_completed_candle() -> None:
-    engine = CandleEngine(instrument_id=InstrumentId("NSE:TEST"))
+    engine = CandleEngine(instrument_id=TEST_INSTRUMENT)
     engine.process(_event(at=datetime(2026, 8, 28, 9, 15, tzinfo=IST), price="100"))
     completed = engine.process(
         _event(at=datetime(2026, 8, 28, 9, 20, tzinfo=IST), price="101")
@@ -121,7 +134,7 @@ def test_late_event_cannot_mutate_or_reemit_completed_candle() -> None:
 
 
 def test_engine_rejects_source_changes_within_one_candle() -> None:
-    engine = CandleEngine(instrument_id=InstrumentId("NSE:TEST"))
+    engine = CandleEngine(instrument_id=TEST_INSTRUMENT)
     engine.process(_event(at=datetime(2026, 8, 28, 9, 15, tzinfo=IST), price="100"))
 
     with pytest.raises(ValueError, match="mix market-event sources"):

--- a/tests/unit/runtime/test_candles.py
+++ b/tests/unit/runtime/test_candles.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.market import MarketEvent
+from signalforge.domain.money import Price
+from signalforge.domain.time import IST
+from signalforge.runtime.candles import CandleEngine, LateMarketEvent, five_minute_interval
+
+
+def _event(
+    *,
+    at: datetime,
+    price: str,
+    quantity: int = 1,
+    instrument_id: InstrumentId = InstrumentId("NSE:TEST"),
+    source: str = "test-feed",
+) -> MarketEvent:
+    return MarketEvent(
+        instrument_id=instrument_id,
+        exchange_timestamp=at,
+        received_timestamp=at,
+        price=Price(Decimal(price)),
+        quantity=quantity,
+        source=source,
+    )
+
+
+def test_five_minute_interval_uses_half_open_nse_boundaries() -> None:
+    before_boundary = five_minute_interval(
+        datetime(2026, 8, 28, 9, 19, 59, 999999, tzinfo=IST)
+    )
+    on_boundary = five_minute_interval(datetime(2026, 8, 28, 9, 20, tzinfo=IST))
+
+    assert before_boundary.start == datetime(2026, 8, 28, 9, 15, tzinfo=IST)
+    assert before_boundary.end == datetime(2026, 8, 28, 9, 20, tzinfo=IST)
+    assert on_boundary.start == datetime(2026, 8, 28, 9, 20, tzinfo=IST)
+    assert on_boundary.end == datetime(2026, 8, 28, 9, 25, tzinfo=IST)
+
+
+def test_equivalent_utc_and_ist_timestamps_map_to_same_interval() -> None:
+    ist_at = datetime(2026, 8, 28, 9, 17, 30, tzinfo=IST)
+    utc_at = ist_at.astimezone(UTC)
+
+    assert five_minute_interval(ist_at) == five_minute_interval(utc_at)
+
+
+def test_engine_builds_deterministic_ohlcv_and_emits_on_next_interval() -> None:
+    instrument = InstrumentId("NSE:TEST")
+    engine = CandleEngine(instrument_id=instrument)
+
+    assert engine.process(_event(at=datetime(2026, 8, 28, 9, 15, tzinfo=IST), price="100", quantity=2)) is None
+    assert engine.process(_event(at=datetime(2026, 8, 28, 9, 16, tzinfo=IST), price="102", quantity=3)) is None
+    assert engine.process(_event(at=datetime(2026, 8, 28, 9, 18, tzinfo=IST), price="99", quantity=5)) is None
+    assert engine.process(_event(at=datetime(2026, 8, 28, 9, 19, tzinfo=IST), price="101", quantity=7)) is None
+
+    candle = engine.process(
+        _event(at=datetime(2026, 8, 28, 9, 20, tzinfo=IST), price="103", quantity=11)
+    )
+
+    assert candle is not None
+    assert candle.instrument_id == instrument
+    assert candle.open == Price(Decimal("100"))
+    assert candle.high == Price(Decimal("102"))
+    assert candle.low == Price(Decimal("99"))
+    assert candle.close == Price(Decimal("101"))
+    assert candle.volume == 17
+    assert candle.source_event_count == 4
+    assert candle.source == "test-feed"
+
+
+def test_gap_does_not_emit_synthetic_empty_candles() -> None:
+    engine = CandleEngine(instrument_id=InstrumentId("NSE:TEST"))
+    engine.process(_event(at=datetime(2026, 8, 28, 9, 15, tzinfo=IST), price="100"))
+
+    first = engine.process(_event(at=datetime(2026, 8, 28, 9, 30, tzinfo=IST), price="105"))
+    assert first is not None
+    assert first.interval.start == datetime(2026, 8, 28, 9, 15, tzinfo=IST)
+    assert engine.active_interval is not None
+    assert engine.active_interval.start == datetime(2026, 8, 28, 9, 30, tzinfo=IST)
+
+    second = engine.process(_event(at=datetime(2026, 8, 28, 9, 35, tzinfo=IST), price="106"))
+    assert second is not None
+    assert second.interval.start == datetime(2026, 8, 28, 9, 30, tzinfo=IST)
+
+
+def test_engine_rejects_mixed_instruments() -> None:
+    engine = CandleEngine(instrument_id=InstrumentId("NSE:TEST"))
+
+    with pytest.raises(ValueError, match="different instrument"):
+        engine.process(
+            _event(
+                at=datetime(2026, 8, 28, 9, 15, tzinfo=IST),
+                price="100",
+                instrument_id=InstrumentId("NSE:OTHER"),
+            )
+        )
+
+
+def test_late_event_cannot_mutate_or_reemit_completed_candle() -> None:
+    engine = CandleEngine(instrument_id=InstrumentId("NSE:TEST"))
+    engine.process(_event(at=datetime(2026, 8, 28, 9, 15, tzinfo=IST), price="100"))
+    completed = engine.process(
+        _event(at=datetime(2026, 8, 28, 9, 20, tzinfo=IST), price="101")
+    )
+    assert completed is not None
+
+    with pytest.raises(LateMarketEvent):
+        engine.process(_event(at=datetime(2026, 8, 28, 9, 19, tzinfo=IST), price="999"))
+
+    next_completed = engine.process(
+        _event(at=datetime(2026, 8, 28, 9, 25, tzinfo=IST), price="102")
+    )
+    assert next_completed is not None
+    assert next_completed.open == Price(Decimal("101"))
+    assert next_completed.close == Price(Decimal("101"))
+
+
+def test_engine_rejects_source_changes_within_one_candle() -> None:
+    engine = CandleEngine(instrument_id=InstrumentId("NSE:TEST"))
+    engine.process(_event(at=datetime(2026, 8, 28, 9, 15, tzinfo=IST), price="100"))
+
+    with pytest.raises(ValueError, match="mix market-event sources"):
+        engine.process(
+            _event(
+                at=datetime(2026, 8, 28, 9, 16, tzinfo=IST),
+                price="101",
+                source="other-feed",
+            )
+        )


### PR DESCRIPTION
## What changed
Implements SF-019 as the first executable M2 market-data component.

- Adds a single-instrument deterministic `CandleEngine`
- Buckets exchange timestamps into canonical Asia/Kolkata five-minute half-open intervals
- Builds OHLCV only from observed normalized `MarketEvent` facts
- Emits the prior immutable `CompletedCandle` when a later interval begins
- Emits no synthetic candles across gaps
- Rejects events for a different instrument
- Rejects late events for older/completed intervals without mutating emitted output
- Preserves source provenance and rejects mixed sources within one candle rather than silently collapsing provenance
- Adds boundary, UTC/IST equivalence, OHLCV, gap, instrument, late-event, and source-provenance tests

## Scope boundary
No session policy, stale-feed policy, replay correction, indicators, broker integration, persistence, or async runtime behavior is introduced.

## Tests
CI runs Ruff, mypy, and pytest.

Closes #39 when merged.