### PR TITLE
SF-020 — Add canonical incremental EMA engine

### DIFF
--- a/signalforge/runtime/ema.py
+++ b/signalforge/runtime/ema.py
@@ -2,30 +2,29 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 
 
-@dataclass(slots=True)
-class Ema:
-    """Incremental EMA with SMA seeding under the frozen Strategy V1 convention."""
+@dataclass(frozen=True, slots=True)
+class EmaState:
+    """Serializable numerical state required to resume one EMA exactly."""
 
     period: int
-    samples: int = 0
-    value: Decimal | None = None
-    _seed_sum: Decimal = Decimal("0")
+    samples: int
+    value: Decimal | None
+    seed_sum: Decimal
 
     def __post_init__(self) -> None:
-        if isinstance(self.period, bool) or not isinstance(self.period, int):
-            raise TypeError("EMA period must be an integer")
-        if self.period <= 0:
-            raise ValueError("EMA period must be strictly positive")
+        _validate_period(self.period)
         if isinstance(self.samples, bool) or not isinstance(self.samples, int):
             raise TypeError("EMA samples must be an integer")
         if self.samples < 0:
             raise ValueError("EMA samples must not be negative")
-        if not isinstance(self._seed_sum, Decimal) or not self._seed_sum.is_finite():
-            raise ValueError("EMA seed sum must be a finite Decimal")
+        if not isinstance(self.seed_sum, Decimal):
+            raise TypeError("EMA seed sum must be a Decimal")
+        if not self.seed_sum.is_finite():
+            raise ValueError("EMA seed sum must be finite")
         if self.value is not None:
             if not isinstance(self.value, Decimal):
                 raise TypeError("EMA value must be a Decimal when provided")
@@ -36,6 +35,36 @@ class Ema:
         if self.samples >= self.period and self.value is None:
             raise ValueError("EMA requires a value once its seed period is complete")
 
+
+def _validate_period(period: int) -> None:
+    if isinstance(period, bool) or not isinstance(period, int):
+        raise TypeError("EMA period must be an integer")
+    if period <= 0:
+        raise ValueError("EMA period must be strictly positive")
+
+
+@dataclass(slots=True)
+class Ema:
+    """Incremental EMA with SMA seeding under the frozen Strategy V1 convention."""
+
+    period: int
+    samples: int = field(default=0, init=False)
+    value: Decimal | None = field(default=None, init=False)
+    _seed_sum: Decimal = field(default=Decimal("0"), init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        _validate_period(self.period)
+
+    @classmethod
+    def from_state(cls, state: EmaState) -> Ema:
+        """Restore an EMA from complete checkpoint state."""
+
+        ema = cls(period=state.period)
+        ema.samples = state.samples
+        ema.value = state.value
+        ema._seed_sum = state.seed_sum
+        return ema
+
     @property
     def ready(self) -> bool:
         return self.value is not None
@@ -43,6 +72,15 @@ class Ema:
     @property
     def alpha(self) -> Decimal:
         return Decimal(2) / Decimal(self.period + 1)
+
+    @property
+    def state(self) -> EmaState:
+        return EmaState(
+            period=self.period,
+            samples=self.samples,
+            value=self.value,
+            seed_sum=self._seed_sum,
+        )
 
     def update(self, close: Decimal) -> Decimal | None:
         """Consume one close and return the current EMA when ready."""

--- a/signalforge/runtime/ema.py
+++ b/signalforge/runtime/ema.py
@@ -1,0 +1,89 @@
+"""Canonical incremental EMA calculations for Strategy V1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(slots=True)
+class Ema:
+    """Incremental EMA with SMA seeding under the frozen Strategy V1 convention."""
+
+    period: int
+    samples: int = 0
+    value: Decimal | None = None
+    _seed_sum: Decimal = Decimal("0")
+
+    def __post_init__(self) -> None:
+        if isinstance(self.period, bool) or not isinstance(self.period, int):
+            raise TypeError("EMA period must be an integer")
+        if self.period <= 0:
+            raise ValueError("EMA period must be strictly positive")
+        if isinstance(self.samples, bool) or not isinstance(self.samples, int):
+            raise TypeError("EMA samples must be an integer")
+        if self.samples < 0:
+            raise ValueError("EMA samples must not be negative")
+        if not isinstance(self._seed_sum, Decimal) or not self._seed_sum.is_finite():
+            raise ValueError("EMA seed sum must be a finite Decimal")
+        if self.value is not None:
+            if not isinstance(self.value, Decimal):
+                raise TypeError("EMA value must be a Decimal when provided")
+            if not self.value.is_finite():
+                raise ValueError("EMA value must be finite")
+        if self.samples < self.period and self.value is not None:
+            raise ValueError("EMA cannot have a value before its seed period is complete")
+        if self.samples >= self.period and self.value is None:
+            raise ValueError("EMA requires a value once its seed period is complete")
+
+    @property
+    def ready(self) -> bool:
+        return self.value is not None
+
+    @property
+    def alpha(self) -> Decimal:
+        return Decimal(2) / Decimal(self.period + 1)
+
+    def update(self, close: Decimal) -> Decimal | None:
+        """Consume one close and return the current EMA when ready."""
+
+        if not isinstance(close, Decimal):
+            raise TypeError("EMA close must be a Decimal")
+        if not close.is_finite():
+            raise ValueError("EMA close must be finite")
+
+        if self.samples < self.period:
+            self._seed_sum += close
+            self.samples += 1
+            if self.samples == self.period:
+                self.value = self._seed_sum / Decimal(self.period)
+            return self.value
+
+        assert self.value is not None
+        self.samples += 1
+        alpha = self.alpha
+        self.value = alpha * close + (Decimal(1) - alpha) * self.value
+        return self.value
+
+
+@dataclass(frozen=True, slots=True)
+class EmaValues:
+    ema9: Decimal | None
+    ema20: Decimal | None
+    ema50: Decimal | None
+
+
+class EmaSet:
+    """Advance EMA(9), EMA(20), and EMA(50) from one canonical close stream."""
+
+    def __init__(self) -> None:
+        self.ema9 = Ema(period=9)
+        self.ema20 = Ema(period=20)
+        self.ema50 = Ema(period=50)
+
+    def update(self, close: Decimal) -> EmaValues:
+        return EmaValues(
+            ema9=self.ema9.update(close),
+            ema20=self.ema20.update(close),
+            ema50=self.ema50.update(close),
+        )

--- a/tests/unit/runtime/test_ema.py
+++ b/tests/unit/runtime/test_ema.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from signalforge.runtime.ema import Ema, EmaSet
+
+
+def test_ema_produces_no_value_before_seed_period() -> None:
+    ema = Ema(period=3)
+
+    assert ema.update(Decimal("10")) is None
+    assert ema.update(Decimal("20")) is None
+    assert ema.ready is False
+    assert ema.samples == 2
+
+
+def test_nth_close_seeds_ema_with_simple_moving_average() -> None:
+    ema = Ema(period=3)
+
+    ema.update(Decimal("10"))
+    ema.update(Decimal("20"))
+    value = ema.update(Decimal("40"))
+
+    assert value == Decimal("70") / Decimal("3")
+    assert ema.value == value
+    assert ema.ready is True
+    assert ema.samples == 3
+
+
+def test_subsequent_close_uses_frozen_recursive_formula() -> None:
+    ema = Ema(period=3)
+    ema.update(Decimal("10"))
+    ema.update(Decimal("20"))
+    seed = ema.update(Decimal("40"))
+    assert seed is not None
+
+    value = ema.update(Decimal("50"))
+    expected = Decimal("0.5") * Decimal("50") + Decimal("0.5") * seed
+
+    assert ema.alpha == Decimal("0.5")
+    assert value == expected
+
+
+def test_constant_series_remains_constant_after_seed() -> None:
+    ema = Ema(period=4)
+
+    values = [ema.update(Decimal("123.45")) for _ in range(8)]
+
+    assert values[:3] == [None, None, None]
+    assert values[3:] == [Decimal("123.45")] * 5
+
+
+def test_awkward_decimal_values_are_processed_as_decimals() -> None:
+    ema = Ema(period=2)
+
+    assert ema.update(Decimal("100.01")) is None
+    seed = ema.update(Decimal("100.02"))
+    assert seed == Decimal("100.015")
+
+    value = ema.update(Decimal("100.04"))
+    expected = ema.alpha * Decimal("100.04") + (Decimal(1) - ema.alpha) * seed
+
+    assert value == expected
+    assert isinstance(value, Decimal)
+
+
+def test_ema_set_tracks_independent_readiness() -> None:
+    emas = EmaSet()
+
+    ninth = None
+    twentieth = None
+    fiftieth = None
+    for index in range(1, 51):
+        values = emas.update(Decimal(index))
+        if index == 9:
+            ninth = values
+        if index == 20:
+            twentieth = values
+        if index == 50:
+            fiftieth = values
+
+    assert ninth is not None
+    assert ninth.ema9 == Decimal("5")
+    assert ninth.ema20 is None
+    assert ninth.ema50 is None
+
+    assert twentieth is not None
+    assert twentieth.ema9 is not None
+    assert twentieth.ema20 == Decimal("10.5")
+    assert twentieth.ema50 is None
+
+    assert fiftieth is not None
+    assert fiftieth.ema9 is not None
+    assert fiftieth.ema20 is not None
+    assert fiftieth.ema50 == Decimal("25.5")
+
+
+def test_batch_replay_matches_incremental_outputs() -> None:
+    closes = [Decimal(index) / Decimal("7") for index in range(1, 65)]
+
+    first = Ema(period=9)
+    incremental = [first.update(close) for close in closes]
+
+    second = Ema(period=9)
+    replayed: list[Decimal | None] = []
+    for close in closes:
+        replayed.append(second.update(close))
+
+    assert replayed == incremental
+    assert second.samples == first.samples
+    assert second.value == first.value
+
+
+def test_ema_rejects_invalid_period_close_and_reconstruction_state() -> None:
+    with pytest.raises(ValueError, match="strictly positive"):
+        Ema(period=0)
+    with pytest.raises(TypeError, match="integer"):
+        Ema(period=True)
+
+    ema = Ema(period=3)
+    with pytest.raises(TypeError, match="Decimal"):
+        ema.update(1.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="finite"):
+        ema.update(Decimal("NaN"))
+
+    with pytest.raises(ValueError, match="before its seed period"):
+        Ema(period=3, samples=2, value=Decimal("10"))
+    with pytest.raises(ValueError, match="requires a value"):
+        Ema(period=3, samples=3, value=None)

--- a/tests/unit/runtime/test_ema.py
+++ b/tests/unit/runtime/test_ema.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 import pytest
 
-from signalforge.runtime.ema import Ema, EmaSet
+from signalforge.runtime.ema import Ema, EmaSet, EmaState
 
 
 def test_ema_produces_no_value_before_seed_period() -> None:
@@ -109,11 +109,41 @@ def test_batch_replay_matches_incremental_outputs() -> None:
         replayed.append(second.update(close))
 
     assert replayed == incremental
-    assert second.samples == first.samples
-    assert second.value == first.value
+    assert second.state == first.state
 
 
-def test_ema_rejects_invalid_period_close_and_reconstruction_state() -> None:
+def test_checkpoint_restore_before_seed_preserves_future_result() -> None:
+    uninterrupted = Ema(period=4)
+    uninterrupted.update(Decimal("10"))
+    uninterrupted.update(Decimal("20"))
+
+    restored = Ema.from_state(uninterrupted.state)
+
+    expected_third = uninterrupted.update(Decimal("30"))
+    actual_third = restored.update(Decimal("30"))
+    expected_seed = uninterrupted.update(Decimal("50"))
+    actual_seed = restored.update(Decimal("50"))
+
+    assert actual_third == expected_third
+    assert actual_seed == expected_seed
+    assert restored.state == uninterrupted.state
+
+
+def test_checkpoint_restore_after_seed_preserves_recursive_result() -> None:
+    uninterrupted = Ema(period=3)
+    for close in (Decimal("10"), Decimal("20"), Decimal("40"), Decimal("50")):
+        uninterrupted.update(close)
+
+    restored = Ema.from_state(uninterrupted.state)
+
+    expected = uninterrupted.update(Decimal("60"))
+    actual = restored.update(Decimal("60"))
+
+    assert actual == expected
+    assert restored.state == uninterrupted.state
+
+
+def test_ema_rejects_invalid_period_close_and_checkpoint_state() -> None:
     with pytest.raises(ValueError, match="strictly positive"):
         Ema(period=0)
     with pytest.raises(TypeError, match="integer"):
@@ -126,6 +156,8 @@ def test_ema_rejects_invalid_period_close_and_reconstruction_state() -> None:
         ema.update(Decimal("NaN"))
 
     with pytest.raises(ValueError, match="before its seed period"):
-        Ema(period=3, samples=2, value=Decimal("10"))
+        EmaState(period=3, samples=2, value=Decimal("10"), seed_sum=Decimal("30"))
     with pytest.raises(ValueError, match="requires a value"):
-        Ema(period=3, samples=3, value=None)
+        EmaState(period=3, samples=3, value=None, seed_sum=Decimal("30"))
+    with pytest.raises(TypeError, match="seed sum"):
+        EmaState(period=3, samples=1, value=None, seed_sum=1)  # type: ignore[arg-type]


### PR DESCRIPTION
## What changed
Implements SF-020 under M2 using the frozen Gate 1 EMA convention.

- Adds reusable incremental `Ema` accumulator
- Adds `EmaSet` for EMA(9), EMA(20), and EMA(50)
- Uses Decimal arithmetic only
- Uses alpha = 2 / (N + 1)
- Seeds the first EMA with the SMA of the first N closes
- Applies the recursive EMA formula thereafter
- Keeps readiness independent for each period
- Exposes sample count/current value state suitable for later checkpoint/recovery work
- Adds tests for seed boundary, recursive updates, constant series, awkward decimals, independent readiness, replay equivalence, and invalid state

## Scope boundary
No RSI, ADX, MACD, strategy evaluation, persistence, session policy, or external TA library is introduced.

Closes #42 when merged.