### PR TITLE
SF-021 — Add canonical incremental RSI(14) engine

### DIFF
--- a/signalforge/runtime/rsi.py
+++ b/signalforge/runtime/rsi.py
@@ -1,0 +1,161 @@
+"""Canonical incremental RSI(14) calculation for Strategy V1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+_PERIOD = 14
+_ZERO = Decimal("0")
+_HUNDRED = Decimal("100")
+_FIFTY = Decimal("50")
+
+
+@dataclass(frozen=True, slots=True)
+class RsiState:
+    """Serializable numerical state required for exact RSI continuation."""
+
+    samples: int
+    previous_close: Decimal | None
+    seed_gain_sum: Decimal
+    seed_loss_sum: Decimal
+    average_gain: Decimal | None
+    average_loss: Decimal | None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.samples, bool) or not isinstance(self.samples, int):
+            raise TypeError("RSI samples must be an integer")
+        if self.samples < 0:
+            raise ValueError("RSI samples must not be negative")
+        _require_optional_finite_decimal(self.previous_close, name="previous_close")
+        _require_finite_decimal(self.seed_gain_sum, name="seed_gain_sum")
+        _require_finite_decimal(self.seed_loss_sum, name="seed_loss_sum")
+        _require_optional_finite_decimal(self.average_gain, name="average_gain")
+        _require_optional_finite_decimal(self.average_loss, name="average_loss")
+        if self.seed_gain_sum < 0 or self.seed_loss_sum < 0:
+            raise ValueError("RSI seed gain/loss sums must not be negative")
+        if self.average_gain is not None and self.average_gain < 0:
+            raise ValueError("RSI average_gain must not be negative")
+        if self.average_loss is not None and self.average_loss < 0:
+            raise ValueError("RSI average_loss must not be negative")
+        self._validate_phase()
+
+    def _validate_phase(self) -> None:
+        changes = max(self.samples - 1, 0)
+        if self.samples == 0:
+            if self.previous_close is not None:
+                raise ValueError("Empty RSI state cannot have previous_close")
+        elif self.previous_close is None:
+            raise ValueError("Non-empty RSI state requires previous_close")
+
+        if changes < _PERIOD:
+            if self.average_gain is not None or self.average_loss is not None:
+                raise ValueError("Unready RSI state cannot have Wilder averages")
+        else:
+            if self.average_gain is None or self.average_loss is None:
+                raise ValueError("Ready RSI state requires Wilder averages")
+            if self.seed_gain_sum != 0 or self.seed_loss_sum != 0:
+                raise ValueError("Ready RSI state must not retain seed sums")
+
+
+class Rsi14:
+    """Incremental Wilder RSI(14) using the frozen Strategy V1 convention."""
+
+    def __init__(self, *, state: RsiState | None = None) -> None:
+        state = state or RsiState(
+            samples=0,
+            previous_close=None,
+            seed_gain_sum=_ZERO,
+            seed_loss_sum=_ZERO,
+            average_gain=None,
+            average_loss=None,
+        )
+        self._samples = state.samples
+        self._previous_close = state.previous_close
+        self._seed_gain_sum = state.seed_gain_sum
+        self._seed_loss_sum = state.seed_loss_sum
+        self._average_gain = state.average_gain
+        self._average_loss = state.average_loss
+
+    @property
+    def samples(self) -> int:
+        return self._samples
+
+    @property
+    def ready(self) -> bool:
+        return self._average_gain is not None
+
+    @property
+    def value(self) -> Decimal | None:
+        if self._average_gain is None or self._average_loss is None:
+            return None
+        return _rsi_value(self._average_gain, self._average_loss)
+
+    def snapshot(self) -> RsiState:
+        return RsiState(
+            samples=self._samples,
+            previous_close=self._previous_close,
+            seed_gain_sum=self._seed_gain_sum,
+            seed_loss_sum=self._seed_loss_sum,
+            average_gain=self._average_gain,
+            average_loss=self._average_loss,
+        )
+
+    def update(self, close: Decimal) -> Decimal | None:
+        """Consume one completed-candle close and return RSI when ready."""
+
+        _require_finite_decimal(close, name="close")
+
+        if self._previous_close is None:
+            self._previous_close = close
+            self._samples = 1
+            return None
+
+        delta = close - self._previous_close
+        gain = max(delta, _ZERO)
+        loss = max(-delta, _ZERO)
+
+        if self._average_gain is None:
+            self._seed_gain_sum += gain
+            self._seed_loss_sum += loss
+            self._samples += 1
+            self._previous_close = close
+            if self._samples == _PERIOD + 1:
+                divisor = Decimal(_PERIOD)
+                self._average_gain = self._seed_gain_sum / divisor
+                self._average_loss = self._seed_loss_sum / divisor
+                self._seed_gain_sum = _ZERO
+                self._seed_loss_sum = _ZERO
+            return self.value
+
+        assert self._average_loss is not None
+        period = Decimal(_PERIOD)
+        self._average_gain = ((self._average_gain * Decimal(_PERIOD - 1)) + gain) / period
+        self._average_loss = ((self._average_loss * Decimal(_PERIOD - 1)) + loss) / period
+        self._samples += 1
+        self._previous_close = close
+        return self.value
+
+
+def _rsi_value(average_gain: Decimal, average_loss: Decimal) -> Decimal:
+    if average_gain == 0 and average_loss == 0:
+        return _FIFTY
+    if average_loss == 0:
+        return _HUNDRED
+    if average_gain == 0:
+        return _ZERO
+    relative_strength = average_gain / average_loss
+    return _HUNDRED - (_HUNDRED / (Decimal(1) + relative_strength))
+
+
+def _require_finite_decimal(value: Decimal, *, name: str) -> None:
+    if not isinstance(value, Decimal):
+        raise TypeError(f"RSI {name} must be a Decimal")
+    if not value.is_finite():
+        raise ValueError(f"RSI {name} must be finite")
+
+
+def _require_optional_finite_decimal(value: Decimal | None, *, name: str) -> None:
+    if value is not None:
+        _require_finite_decimal(value, name=name)

--- a/signalforge/runtime/rsi.py
+++ b/signalforge/runtime/rsi.py
@@ -1,10 +1,7 @@
 """Canonical incremental RSI(14) calculation for Strategy V1."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from decimal import Decimal
-
 
 _PERIOD = 14
 _ZERO = Decimal("0")

--- a/tests/unit/runtime/test_rsi.py
+++ b/tests/unit/runtime/test_rsi.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from signalforge.runtime.rsi import Rsi14, RsiState
+
+
+def _run(closes: list[str]) -> list[Decimal | None]:
+    rsi = Rsi14()
+    return [rsi.update(Decimal(close)) for close in closes]
+
+
+def test_first_rsi_is_produced_on_fifteenth_close() -> None:
+    rsi = Rsi14()
+
+    for close in range(1, 15):
+        assert rsi.update(Decimal(close)) is None
+
+    assert rsi.update(Decimal("15")) == Decimal("100")
+    assert rsi.ready is True
+    assert rsi.samples == 15
+
+
+def test_rising_falling_and_constant_seed_edge_cases() -> None:
+    rising = [str(value) for value in range(1, 16)]
+    falling = [str(value) for value in range(15, 0, -1)]
+    constant = ["123.45"] * 15
+
+    assert _run(rising)[-1] == Decimal("100")
+    assert _run(falling)[-1] == Decimal("0")
+    assert _run(constant)[-1] == Decimal("50")
+
+
+def test_first_rsi_uses_arithmetic_mean_seed_averages() -> None:
+    closes = [Decimal("100")]
+    deltas = [
+        Decimal("1"),
+        Decimal("-2"),
+        Decimal("3"),
+        Decimal("-4"),
+        Decimal("5"),
+        Decimal("-6"),
+        Decimal("7"),
+        Decimal("-8"),
+        Decimal("9"),
+        Decimal("-10"),
+        Decimal("11"),
+        Decimal("-12"),
+        Decimal("13"),
+        Decimal("-14"),
+    ]
+    for delta in deltas:
+        closes.append(closes[-1] + delta)
+
+    rsi = Rsi14()
+    values = [rsi.update(close) for close in closes]
+
+    average_gain = Decimal("49") / Decimal("14")
+    average_loss = Decimal("56") / Decimal("14")
+    expected = Decimal("100") - (
+        Decimal("100") / (Decimal("1") + average_gain / average_loss)
+    )
+    assert values[-1] == expected
+
+
+def test_subsequent_value_uses_wilder_smoothing() -> None:
+    rsi = Rsi14()
+    closes = [Decimal(value) for value in range(1, 16)]
+    for close in closes:
+        rsi.update(close)
+
+    assert rsi.value == Decimal("100")
+    value = rsi.update(Decimal("14"))
+
+    average_gain = Decimal("13") / Decimal("14")
+    average_loss = Decimal("1") / Decimal("14")
+    expected = Decimal("100") - (
+        Decimal("100") / (Decimal("1") + average_gain / average_loss)
+    )
+    assert value == expected
+
+
+def test_awkward_decimals_remain_decimal_and_deterministic() -> None:
+    closes = [Decimal("100.01") + Decimal(index) / Decimal("37") for index in range(20)]
+
+    first = Rsi14()
+    first_values = [first.update(close) for close in closes]
+
+    second = Rsi14()
+    second_values = [second.update(close) for close in closes]
+
+    assert first_values == second_values
+    assert isinstance(first_values[-1], Decimal)
+
+
+def test_checkpoint_restore_before_readiness_matches_uninterrupted_path() -> None:
+    closes = [Decimal(index) / Decimal("7") for index in range(1, 25)]
+
+    uninterrupted = Rsi14()
+    uninterrupted_values = [uninterrupted.update(close) for close in closes]
+
+    partial = Rsi14()
+    for close in closes[:8]:
+        partial.update(close)
+    restored = Rsi14(state=partial.snapshot())
+    restored_values = [restored.update(close) for close in closes[8:]]
+
+    assert restored_values == uninterrupted_values[8:]
+    assert restored.snapshot() == uninterrupted.snapshot()
+
+
+def test_checkpoint_restore_after_readiness_matches_uninterrupted_path() -> None:
+    closes = [Decimal(index * index) / Decimal("11") for index in range(1, 30)]
+
+    uninterrupted = Rsi14()
+    uninterrupted_values = [uninterrupted.update(close) for close in closes]
+
+    partial = Rsi14()
+    for close in closes[:20]:
+        partial.update(close)
+    restored = Rsi14(state=partial.snapshot())
+    restored_values = [restored.update(close) for close in closes[20:]]
+
+    assert restored_values == uninterrupted_values[20:]
+    assert restored.snapshot() == uninterrupted.snapshot()
+
+
+def test_rsi_rejects_invalid_input_and_inconsistent_reconstruction_state() -> None:
+    rsi = Rsi14()
+    with pytest.raises(TypeError, match="Decimal"):
+        rsi.update(1.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="finite"):
+        rsi.update(Decimal("NaN"))
+
+    with pytest.raises(ValueError, match="previous_close"):
+        RsiState(
+            samples=1,
+            previous_close=None,
+            seed_gain_sum=Decimal("0"),
+            seed_loss_sum=Decimal("0"),
+            average_gain=None,
+            average_loss=None,
+        )
+
+    with pytest.raises(ValueError, match="Wilder averages"):
+        RsiState(
+            samples=15,
+            previous_close=Decimal("100"),
+            seed_gain_sum=Decimal("0"),
+            seed_loss_sum=Decimal("0"),
+            average_gain=None,
+            average_loss=None,
+        )
+
+    with pytest.raises(ValueError, match="seed sums"):
+        RsiState(
+            samples=15,
+            previous_close=Decimal("100"),
+            seed_gain_sum=Decimal("1"),
+            seed_loss_sum=Decimal("0"),
+            average_gain=Decimal("1"),
+            average_loss=Decimal("1"),
+        )


### PR DESCRIPTION
## What changed
Implements SF-021 under M2 using the frozen Gate 1 Wilder RSI convention.

- Adds restart-safe incremental `Rsi14`
- First close establishes prior-close state
- Seeds from the first 14 close-to-close changes; first RSI appears on the 15th close
- Uses Decimal arithmetic throughout
- Uses arithmetic-mean initial gain/loss averages
- Uses exact Wilder smoothing thereafter
- Implements explicit RSI edge cases: 100, 0, and 50 for zero-loss/zero-gain combinations
- Adds immutable `RsiState` for exact checkpoint/recovery
- Tests seed readiness, mixed gain/loss seed math, Wilder recursion, edge cases, awkward decimals, batch determinism, restart before readiness, restart after readiness, and reconstruction invariants

## Scope boundary
No ADX, MACD, combined IndicatorEngine, persistence, strategy evaluation, session policy, or external TA-library authority is introduced.

Closes #44 when merged.