### PR TITLE
SF-022 — Add canonical incremental ADX(14) engine

### DIFF
--- a/signalforge/runtime/adx.py
+++ b/signalforge/runtime/adx.py
@@ -1,0 +1,254 @@
+"""Canonical incremental ADX(14) calculation for Strategy V1."""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+_PERIOD = 14
+_ZERO = Decimal("0")
+_HUNDRED = Decimal("100")
+
+
+@dataclass(frozen=True, slots=True)
+class AdxValues:
+    tr: Decimal | None
+    plus_dm: Decimal | None
+    minus_dm: Decimal | None
+    plus_di: Decimal | None
+    minus_di: Decimal | None
+    dx: Decimal | None
+    adx: Decimal | None
+
+
+@dataclass(frozen=True, slots=True)
+class AdxState:
+    samples: int
+    previous_high: Decimal | None
+    previous_low: Decimal | None
+    previous_close: Decimal | None
+    seed_tr_sum: Decimal
+    seed_plus_dm_sum: Decimal
+    seed_minus_dm_sum: Decimal
+    smoothed_tr: Decimal | None
+    smoothed_plus_dm: Decimal | None
+    smoothed_minus_dm: Decimal | None
+    dx_seed_sum: Decimal
+    dx_seed_count: int
+    adx: Decimal | None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.samples, bool) or not isinstance(self.samples, int):
+            raise TypeError("ADX samples must be an integer")
+        if self.samples < 0:
+            raise ValueError("ADX samples must not be negative")
+        if isinstance(self.dx_seed_count, bool) or not isinstance(self.dx_seed_count, int):
+            raise TypeError("ADX dx_seed_count must be an integer")
+        if not 0 <= self.dx_seed_count <= _PERIOD:
+            raise ValueError("ADX dx_seed_count must be between 0 and 14")
+
+        for name, value in (
+            ("previous_high", self.previous_high),
+            ("previous_low", self.previous_low),
+            ("previous_close", self.previous_close),
+            ("smoothed_tr", self.smoothed_tr),
+            ("smoothed_plus_dm", self.smoothed_plus_dm),
+            ("smoothed_minus_dm", self.smoothed_minus_dm),
+            ("adx", self.adx),
+        ):
+            _require_optional_decimal(value, name=name)
+        for name, value in (
+            ("seed_tr_sum", self.seed_tr_sum),
+            ("seed_plus_dm_sum", self.seed_plus_dm_sum),
+            ("seed_minus_dm_sum", self.seed_minus_dm_sum),
+            ("dx_seed_sum", self.dx_seed_sum),
+        ):
+            _require_decimal(value, name=name)
+            if value < 0:
+                raise ValueError(f"ADX {name} must not be negative")
+
+        previous = (self.previous_high, self.previous_low, self.previous_close)
+        if self.samples == 0:
+            if any(value is not None for value in previous):
+                raise ValueError("Empty ADX state cannot retain previous candle values")
+        elif any(value is None for value in previous):
+            raise ValueError("Non-empty ADX state requires previous candle values")
+
+        smoothed = (self.smoothed_tr, self.smoothed_plus_dm, self.smoothed_minus_dm)
+        if self.samples < _PERIOD + 1:
+            if any(value is not None for value in smoothed):
+                raise ValueError("ADX smoothing cannot exist before C14")
+            if self.dx_seed_count != 0 or self.dx_seed_sum != 0 or self.adx is not None:
+                raise ValueError("ADX/DX seed state cannot exist before C14")
+        else:
+            if any(value is None for value in smoothed):
+                raise ValueError("ADX smoothing is required from C14 onward")
+            if self.samples < 28 and self.adx is not None:
+                raise ValueError("ADX cannot be ready before C27")
+            if self.samples >= 28:
+                if self.adx is None:
+                    raise ValueError("ADX is required from C27 onward")
+                if self.dx_seed_count != _PERIOD or self.dx_seed_sum != 0:
+                    raise ValueError("Ready ADX state must have completed and cleared its DX seed")
+
+
+class Adx14:
+    """Incremental Wilder ADX(14) with the frozen Gate 1 indexing convention."""
+
+    def __init__(self, *, state: AdxState | None = None) -> None:
+        state = state or AdxState(
+            samples=0,
+            previous_high=None,
+            previous_low=None,
+            previous_close=None,
+            seed_tr_sum=_ZERO,
+            seed_plus_dm_sum=_ZERO,
+            seed_minus_dm_sum=_ZERO,
+            smoothed_tr=None,
+            smoothed_plus_dm=None,
+            smoothed_minus_dm=None,
+            dx_seed_sum=_ZERO,
+            dx_seed_count=0,
+            adx=None,
+        )
+        self._state = state
+
+    @property
+    def samples(self) -> int:
+        return self._state.samples
+
+    @property
+    def ready(self) -> bool:
+        return self._state.adx is not None
+
+    @property
+    def value(self) -> Decimal | None:
+        return self._state.adx
+
+    def snapshot(self) -> AdxState:
+        return self._state
+
+    def update(self, high: Decimal, low: Decimal, close: Decimal) -> AdxValues:
+        for name, value in (("high", high), ("low", low), ("close", close)):
+            _require_decimal(value, name=name)
+        if high < low:
+            raise ValueError("ADX high must be greater than or equal to low")
+
+        s = self._state
+        if s.samples == 0:
+            self._state = AdxState(
+                samples=1,
+                previous_high=high,
+                previous_low=low,
+                previous_close=close,
+                seed_tr_sum=_ZERO,
+                seed_plus_dm_sum=_ZERO,
+                seed_minus_dm_sum=_ZERO,
+                smoothed_tr=None,
+                smoothed_plus_dm=None,
+                smoothed_minus_dm=None,
+                dx_seed_sum=_ZERO,
+                dx_seed_count=0,
+                adx=None,
+            )
+            return AdxValues(None, None, None, None, None, None, None)
+
+        assert s.previous_high is not None
+        assert s.previous_low is not None
+        assert s.previous_close is not None
+
+        up_move = high - s.previous_high
+        down_move = s.previous_low - low
+        plus_dm = up_move if up_move > down_move and up_move > 0 else _ZERO
+        minus_dm = down_move if down_move > up_move and down_move > 0 else _ZERO
+        tr = max(high - low, abs(high - s.previous_close), abs(low - s.previous_close))
+        samples = s.samples + 1
+
+        if samples <= _PERIOD + 1:
+            seed_tr = s.seed_tr_sum + tr
+            seed_plus = s.seed_plus_dm_sum + plus_dm
+            seed_minus = s.seed_minus_dm_sum + minus_dm
+            if samples < _PERIOD + 1:
+                self._state = AdxState(
+                    samples=samples,
+                    previous_high=high,
+                    previous_low=low,
+                    previous_close=close,
+                    seed_tr_sum=seed_tr,
+                    seed_plus_dm_sum=seed_plus,
+                    seed_minus_dm_sum=seed_minus,
+                    smoothed_tr=None,
+                    smoothed_plus_dm=None,
+                    smoothed_minus_dm=None,
+                    dx_seed_sum=_ZERO,
+                    dx_seed_count=0,
+                    adx=None,
+                )
+                return AdxValues(tr, plus_dm, minus_dm, None, None, None, None)
+            smoothed_tr = seed_tr
+            smoothed_plus = seed_plus
+            smoothed_minus = seed_minus
+        else:
+            assert s.smoothed_tr is not None
+            assert s.smoothed_plus_dm is not None
+            assert s.smoothed_minus_dm is not None
+            period = Decimal(_PERIOD)
+            smoothed_tr = s.smoothed_tr - (s.smoothed_tr / period) + tr
+            smoothed_plus = s.smoothed_plus_dm - (s.smoothed_plus_dm / period) + plus_dm
+            smoothed_minus = s.smoothed_minus_dm - (s.smoothed_minus_dm / period) + minus_dm
+
+        plus_di, minus_di, dx = _directional_values(smoothed_tr, smoothed_plus, smoothed_minus)
+
+        adx = s.adx
+        dx_seed_sum = s.dx_seed_sum
+        dx_seed_count = s.dx_seed_count
+        if adx is None:
+            dx_seed_sum += dx
+            dx_seed_count += 1
+            if dx_seed_count == _PERIOD:
+                adx = dx_seed_sum / Decimal(_PERIOD)
+                dx_seed_sum = _ZERO
+        else:
+            adx = ((adx * Decimal(_PERIOD - 1)) + dx) / Decimal(_PERIOD)
+
+        self._state = AdxState(
+            samples=samples,
+            previous_high=high,
+            previous_low=low,
+            previous_close=close,
+            seed_tr_sum=_ZERO,
+            seed_plus_dm_sum=_ZERO,
+            seed_minus_dm_sum=_ZERO,
+            smoothed_tr=smoothed_tr,
+            smoothed_plus_dm=smoothed_plus,
+            smoothed_minus_dm=smoothed_minus,
+            dx_seed_sum=dx_seed_sum,
+            dx_seed_count=dx_seed_count,
+            adx=adx,
+        )
+        return AdxValues(tr, plus_dm, minus_dm, plus_di, minus_di, dx, adx)
+
+
+def _directional_values(
+    smoothed_tr: Decimal,
+    smoothed_plus_dm: Decimal,
+    smoothed_minus_dm: Decimal,
+) -> tuple[Decimal, Decimal, Decimal]:
+    if smoothed_tr == 0:
+        plus_di = minus_di = _ZERO
+    else:
+        plus_di = _HUNDRED * smoothed_plus_dm / smoothed_tr
+        minus_di = _HUNDRED * smoothed_minus_dm / smoothed_tr
+    denominator = plus_di + minus_di
+    dx = _ZERO if denominator == 0 else _HUNDRED * abs(plus_di - minus_di) / denominator
+    return plus_di, minus_di, dx
+
+
+def _require_decimal(value: Decimal, *, name: str) -> None:
+    if not isinstance(value, Decimal):
+        raise TypeError(f"ADX {name} must be a Decimal")
+    if not value.is_finite():
+        raise ValueError(f"ADX {name} must be finite")
+
+
+def _require_optional_decimal(value: Decimal | None, *, name: str) -> None:
+    if value is not None:
+        _require_decimal(value, name=name)

--- a/tests/unit/runtime/test_adx.py
+++ b/tests/unit/runtime/test_adx.py
@@ -1,0 +1,164 @@
+from decimal import Decimal
+
+import pytest
+
+from signalforge.runtime.adx import Adx14, AdxState
+
+
+def _trend_candle(index: int) -> tuple[Decimal, Decimal, Decimal]:
+    base = Decimal(index)
+    return base + Decimal("11"), base + Decimal("9"), base + Decimal("10")
+
+
+def test_first_candle_creates_no_raw_adx_observation() -> None:
+    adx = Adx14()
+
+    values = adx.update(Decimal("10"), Decimal("8"), Decimal("9"))
+
+    assert values.tr is None
+    assert values.plus_dm is None
+    assert values.minus_dm is None
+    assert values.dx is None
+    assert adx.samples == 1
+
+
+def test_raw_tr_and_directional_movement_follow_wilder_rules() -> None:
+    adx = Adx14()
+    adx.update(Decimal("10"), Decimal("8"), Decimal("9"))
+
+    values = adx.update(Decimal("12"), Decimal("8.5"), Decimal("11"))
+
+    assert values.tr == Decimal("3.5")
+    assert values.plus_dm == Decimal("2")
+    assert values.minus_dm == Decimal("0")
+
+
+def test_tied_directional_moves_produce_zero_dm() -> None:
+    adx = Adx14()
+    adx.update(Decimal("10"), Decimal("8"), Decimal("9"))
+
+    values = adx.update(Decimal("11"), Decimal("7"), Decimal("9"))
+
+    assert values.plus_dm == 0
+    assert values.minus_dm == 0
+
+
+def test_first_di_and_dx_are_available_on_c14() -> None:
+    adx = Adx14()
+    outputs = []
+    for index in range(15):
+        outputs.append(adx.update(*_trend_candle(index)))
+
+    assert outputs[13].plus_di is None
+    assert outputs[13].dx is None
+    assert outputs[14].plus_di == Decimal("50")
+    assert outputs[14].minus_di == Decimal("0")
+    assert outputs[14].dx == Decimal("100")
+    assert outputs[14].adx is None
+
+
+def test_first_adx_is_ready_on_c27_not_c26() -> None:
+    adx = Adx14()
+    outputs = [adx.update(*_trend_candle(index)) for index in range(28)]
+
+    assert outputs[26].adx is None
+    assert outputs[27].adx == Decimal("100")
+    assert adx.ready is True
+
+
+def test_first_adx_seed_uses_exactly_fourteen_dx_values() -> None:
+    adx = Adx14()
+    for index in range(27):
+        adx.update(*_trend_candle(index))
+
+    before = adx.snapshot()
+    assert before.samples == 27
+    assert before.dx_seed_count == 13
+    assert before.dx_seed_sum == Decimal("1300")
+    assert before.adx is None
+
+    values = adx.update(*_trend_candle(27))
+    after = adx.snapshot()
+    assert values.dx == Decimal("100")
+    assert values.adx == Decimal("100")
+    assert after.dx_seed_count == 14
+    assert after.dx_seed_sum == 0
+
+
+def test_zero_denominators_produce_zero_di_dx_and_adx() -> None:
+    adx = Adx14()
+    outputs = [
+        adx.update(Decimal("10"), Decimal("10"), Decimal("10"))
+        for _ in range(28)
+    ]
+
+    assert outputs[14].plus_di == 0
+    assert outputs[14].minus_di == 0
+    assert outputs[14].dx == 0
+    assert outputs[27].adx == 0
+
+
+def test_wilder_adx_recursion_uses_unrounded_previous_value() -> None:
+    adx = Adx14()
+    for index in range(28):
+        adx.update(*_trend_candle(index))
+    previous = adx.value
+    assert previous == Decimal("100")
+
+    values = adx.update(Decimal("37"), Decimal("20"), Decimal("21"))
+    assert values.dx is not None
+    expected = ((previous * Decimal("13")) + values.dx) / Decimal("14")
+    assert values.adx == expected
+
+
+def test_checkpoint_restore_before_readiness_is_exact() -> None:
+    uninterrupted = Adx14()
+    closes = [_trend_candle(index) for index in range(40)]
+    for candle in closes[:10]:
+        uninterrupted.update(*candle)
+
+    restored = Adx14(state=uninterrupted.snapshot())
+    expected = [uninterrupted.update(*candle) for candle in closes[10:]]
+    actual = [restored.update(*candle) for candle in closes[10:]]
+
+    assert actual == expected
+    assert restored.snapshot() == uninterrupted.snapshot()
+
+
+def test_checkpoint_restore_after_readiness_is_exact() -> None:
+    uninterrupted = Adx14()
+    candles = [_trend_candle(index) for index in range(45)]
+    for candle in candles[:32]:
+        uninterrupted.update(*candle)
+
+    restored = Adx14(state=uninterrupted.snapshot())
+    expected = [uninterrupted.update(*candle) for candle in candles[32:]]
+    actual = [restored.update(*candle) for candle in candles[32:]]
+
+    assert actual == expected
+    assert restored.snapshot() == uninterrupted.snapshot()
+
+
+def test_invalid_input_and_reconstruction_state_are_rejected() -> None:
+    adx = Adx14()
+    with pytest.raises(TypeError, match="Decimal"):
+        adx.update(10.0, Decimal("9"), Decimal("9.5"))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="greater than or equal"):
+        adx.update(Decimal("8"), Decimal("9"), Decimal("8.5"))
+
+    with pytest.raises(ValueError, match="cannot be ready before C27"):
+        AdxState(
+            samples=20,
+            previous_high=Decimal("10"),
+            previous_low=Decimal("9"),
+            previous_close=Decimal("9.5"),
+            seed_tr_sum=Decimal("0"),
+            seed_plus_dm_sum=Decimal("0"),
+            seed_minus_dm_sum=Decimal("0"),
+            smoothed_tr=Decimal("14"),
+            smoothed_plus_dm=Decimal("7"),
+            smoothed_minus_dm=Decimal("0"),
+            dx_seed_sum=Decimal("500"),
+            dx_seed_count=5,
+            adx=Decimal("100"),
+        )


### PR DESCRIPTION
## What changed
Implements SF-022 under M2 using the recovered frozen Gate 1 ADX(14) numerical contract.

- No TR/+DM/-DM observation for C0
- First raw observation at C1
- Initial smoothed TR/+DM/-DM are sums of observations C1..C14
- First +DI/-DI/DX at C14
- First ADX is mean(DX14..DX27), therefore ready at C27 / candle #28
- Wilder TR/DM and ADX recursion thereafter
- Zero-denominator DI/DX behavior returns canonical zero
- Decimal arithmetic with no intermediate rounding
- Immutable restart-safe AdxState
- Tests for raw TR/DM rules, tie handling, first DI/DX timing, exact ADX seed count, C26/C27 readiness boundary, zero denominators, recursive ADX, checkpoint recovery, and invalid state

## Scope boundary
No MACD, combined IndicatorEngine, persistence, strategy evaluation, session policy, or external TA-library authority is introduced.

Closes #46 when merged.