### PR TITLE
SF-022 — Add canonical incremental ADX(14) engine

### DIFF
--- a/signalforge/runtime/adx.py
+++ b/signalforge/runtime/adx.py
@@ -81,9 +81,13 @@ class AdxState:
         else:
             if any(value is None for value in smoothed):
                 raise ValueError("ADX smoothing is required from C14 onward")
-            if self.samples < 28 and self.adx is not None:
-                raise ValueError("ADX cannot be ready before C27")
-            if self.samples >= 28:
+            if self.samples < 28:
+                if self.adx is not None:
+                    raise ValueError("ADX cannot be ready before C27")
+                expected_dx_count = self.samples - _PERIOD
+                if self.dx_seed_count != expected_dx_count:
+                    raise ValueError("ADX DX seed count must match candle progress")
+            else:
                 if self.adx is None:
                     raise ValueError("ADX is required from C27 onward")
                 if self.dx_seed_count != _PERIOD or self.dx_seed_sum != 0:

--- a/tests/unit/runtime/test_adx.py
+++ b/tests/unit/runtime/test_adx.py
@@ -139,6 +139,25 @@ def test_checkpoint_restore_after_readiness_is_exact() -> None:
     assert restored.snapshot() == uninterrupted.snapshot()
 
 
+def test_checkpoint_dx_seed_count_must_match_candle_progress() -> None:
+    with pytest.raises(ValueError, match="seed count must match candle progress"):
+        AdxState(
+            samples=20,
+            previous_high=Decimal("10"),
+            previous_low=Decimal("9"),
+            previous_close=Decimal("9.5"),
+            seed_tr_sum=Decimal("0"),
+            seed_plus_dm_sum=Decimal("0"),
+            seed_minus_dm_sum=Decimal("0"),
+            smoothed_tr=Decimal("14"),
+            smoothed_plus_dm=Decimal("7"),
+            smoothed_minus_dm=Decimal("0"),
+            dx_seed_sum=Decimal("500"),
+            dx_seed_count=5,
+            adx=None,
+        )
+
+
 def test_invalid_input_and_reconstruction_state_are_rejected() -> None:
     adx = Adx14()
     with pytest.raises(TypeError, match="Decimal"):


### PR DESCRIPTION
## What changed
Implements SF-022 under M2 using the recovered frozen Gate 1 ADX(14) numerical contract.

- No TR/+DM/-DM observation on C0
- First raw observation on C1
- Initial Wilder TR/+DM/-DM seed is the sum of observations C1..C14
- First +DI/-DI and DX on C14
- First ADX is the arithmetic mean of exactly DX14..DX27
- ADX not ready on C26; ready on C27 / 28th candle
- Recursive Wilder ADX from C28 onward
- Zero denominators produce canonical zero DI/DX values
- Decimal arithmetic with no intermediate rounding
- Immutable restart-safe `AdxState`
- Checkpoint validation ties DX seed progress to candle progress
- Tests cover raw TR/DM, tie rules, DI/DX readiness, ADX seed boundary, zero denominators, recursion, and restart before/after readiness

## Scope boundary
No MACD, combined IndicatorEngine, persistence, strategy evaluation, session policy, or external TA-library authority is introduced.

Closes #46 when merged.