### PR TITLE
CI — Add coverage reporting to validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Mypy
         run: mypy signalforge
 
-      - name: Pytest
-        run: pytest
+      - name: Pytest with coverage
+        run: pytest --cov=signalforge --cov-report=term-missing


### PR DESCRIPTION
## What changed

- Keeps the existing single Python 3.12 validation job
- Keeps Ruff and strict mypy unchanged
- Changes pytest to `pytest --cov=signalforge --cov-report=term-missing`
- Uses the existing pytest-cov dependency and branch coverage configuration
- Does not introduce a coverage fail-under threshold yet

## Why
Coverage was already configured in `pyproject.toml` and pytest-cov was installed, but CI was running plain pytest, so coverage was invisible. This change exposes the actual baseline before any enforcement percentage is chosen.

Closes #51 when merged, except for required-status-check enforcement if that repository setting cannot be changed through the available connector.