### PR TITLE
SF-023 — Add canonical incremental MACD(12,26,9) engine

### DIFF
--- a/signalforge/runtime/macd.py
+++ b/signalforge/runtime/macd.py
@@ -1,0 +1,103 @@
+"""Canonical incremental MACD(12,26,9) calculation for Strategy V1."""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from signalforge.runtime.ema import Ema, EmaState
+
+_FAST_PERIOD = 12
+_SLOW_PERIOD = 26
+_SIGNAL_PERIOD = 9
+
+
+@dataclass(frozen=True, slots=True)
+class MacdValues:
+    ema12: Decimal | None
+    ema26: Decimal | None
+    macd_line: Decimal | None
+    signal_line: Decimal | None
+    histogram: Decimal | None
+
+
+@dataclass(frozen=True, slots=True)
+class MacdState:
+    samples: int
+    fast_ema: EmaState
+    slow_ema: EmaState
+    signal_ema: EmaState
+
+    def __post_init__(self) -> None:
+        if isinstance(self.samples, bool) or not isinstance(self.samples, int):
+            raise TypeError("MACD samples must be an integer")
+        if self.samples < 0:
+            raise ValueError("MACD samples must not be negative")
+        if self.fast_ema.period != _FAST_PERIOD:
+            raise ValueError("MACD fast EMA state must use period 12")
+        if self.slow_ema.period != _SLOW_PERIOD:
+            raise ValueError("MACD slow EMA state must use period 26")
+        if self.signal_ema.period != _SIGNAL_PERIOD:
+            raise ValueError("MACD signal EMA state must use period 9")
+        if self.fast_ema.samples != self.samples:
+            raise ValueError("MACD fast EMA sample count must match MACD sample count")
+        if self.slow_ema.samples != self.samples:
+            raise ValueError("MACD slow EMA sample count must match MACD sample count")
+
+        expected_signal_samples = max(0, self.samples - (_SLOW_PERIOD - 1))
+        if self.signal_ema.samples != expected_signal_samples:
+            raise ValueError("MACD signal EMA sample count must match valid MACD observations")
+
+
+class Macd12269:
+    """Incremental MACD(12,26,9) with the frozen Gate 1 readiness convention."""
+
+    def __init__(self, *, state: MacdState | None = None) -> None:
+        if state is None:
+            self._fast = Ema(period=_FAST_PERIOD)
+            self._slow = Ema(period=_SLOW_PERIOD)
+            self._signal = Ema(period=_SIGNAL_PERIOD)
+            self._samples = 0
+        else:
+            self._fast = Ema.from_state(state.fast_ema)
+            self._slow = Ema.from_state(state.slow_ema)
+            self._signal = Ema.from_state(state.signal_ema)
+            self._samples = state.samples
+
+    @property
+    def samples(self) -> int:
+        return self._samples
+
+    @property
+    def macd_ready(self) -> bool:
+        return self._slow.ready
+
+    @property
+    def fully_ready(self) -> bool:
+        return self._signal.ready
+
+    @property
+    def state(self) -> MacdState:
+        return MacdState(
+            samples=self._samples,
+            fast_ema=self._fast.state,
+            slow_ema=self._slow.state,
+            signal_ema=self._signal.state,
+        )
+
+    def update(self, close: Decimal) -> MacdValues:
+        if not isinstance(close, Decimal):
+            raise TypeError("MACD close must be a Decimal")
+        if not close.is_finite():
+            raise ValueError("MACD close must be finite")
+
+        ema12 = self._fast.update(close)
+        ema26 = self._slow.update(close)
+        self._samples += 1
+
+        if ema26 is None:
+            return MacdValues(ema12, None, None, None, None)
+
+        assert ema12 is not None
+        macd_line = ema12 - ema26
+        signal_line = self._signal.update(macd_line)
+        histogram = None if signal_line is None else macd_line - signal_line
+        return MacdValues(ema12, ema26, macd_line, signal_line, histogram)

--- a/tests/unit/runtime/test_macd.py
+++ b/tests/unit/runtime/test_macd.py
@@ -1,0 +1,151 @@
+from decimal import Decimal
+
+import pytest
+
+from signalforge.runtime.macd import Macd12269, MacdState
+
+
+def _closes(count: int) -> list[Decimal]:
+    return [Decimal(index) + Decimal("100.125") for index in range(count)]
+
+
+def test_readiness_boundaries_match_gate_1_contract() -> None:
+    macd = Macd12269()
+    outputs = [macd.update(close) for close in _closes(34)]
+
+    assert outputs[10].ema12 is None
+    assert outputs[11].ema12 is not None
+
+    assert outputs[24].ema26 is None
+    assert outputs[24].macd_line is None
+    assert outputs[25].ema26 is not None
+    assert outputs[25].macd_line is not None
+
+    assert outputs[32].signal_line is None
+    assert outputs[32].histogram is None
+    assert outputs[33].signal_line is not None
+    assert outputs[33].histogram is not None
+
+
+def test_macd_line_is_available_before_signal_and_histogram() -> None:
+    macd = Macd12269()
+    outputs = [macd.update(close) for close in _closes(33)]
+
+    for output in outputs[25:33]:
+        assert output.macd_line is not None
+        assert output.signal_line is None
+        assert output.histogram is None
+
+
+def test_signal_seed_uses_exactly_first_nine_macd_values() -> None:
+    macd = Macd12269()
+    outputs = [macd.update(close) for close in _closes(34)]
+
+    macd_seed = [output.macd_line for output in outputs[25:34]]
+    assert all(value is not None for value in macd_seed)
+    expected = sum((value for value in macd_seed if value is not None), Decimal("0")) / Decimal(9)
+
+    assert outputs[32].signal_line is None
+    assert outputs[33].signal_line == expected
+    assert macd.state.signal_ema.samples == 9
+
+
+def test_histogram_is_macd_minus_signal() -> None:
+    macd = Macd12269()
+    output = None
+    for close in _closes(34):
+        output = macd.update(close)
+
+    assert output is not None
+    assert output.macd_line is not None
+    assert output.signal_line is not None
+    assert output.histogram == output.macd_line - output.signal_line
+
+
+def test_constant_series_produces_valid_zero_values_when_ready() -> None:
+    macd = Macd12269()
+    outputs = [macd.update(Decimal("100")) for _ in range(34)]
+
+    assert outputs[25].macd_line == Decimal("0")
+    assert outputs[25].signal_line is None
+    assert outputs[33].macd_line == Decimal("0")
+    assert outputs[33].signal_line == Decimal("0")
+    assert outputs[33].histogram == Decimal("0")
+
+
+def test_recursive_signal_ema_uses_unrounded_previous_value() -> None:
+    macd = Macd12269()
+    outputs = [macd.update(close) for close in _closes(35)]
+
+    previous_signal = outputs[33].signal_line
+    current_macd = outputs[34].macd_line
+    assert previous_signal is not None
+    assert current_macd is not None
+
+    alpha = Decimal("0.2")
+    expected = alpha * current_macd + (Decimal("1") - alpha) * previous_signal
+    assert outputs[34].signal_line == expected
+
+
+def test_checkpoint_restore_before_macd_readiness_is_exact() -> None:
+    uninterrupted = Macd12269()
+    closes = _closes(45)
+    for close in closes[:10]:
+        uninterrupted.update(close)
+
+    restored = Macd12269(state=uninterrupted.state)
+    expected = [uninterrupted.update(close) for close in closes[10:]]
+    actual = [restored.update(close) for close in closes[10:]]
+
+    assert actual == expected
+    assert restored.state == uninterrupted.state
+
+
+def test_checkpoint_restore_during_partial_readiness_is_exact() -> None:
+    uninterrupted = Macd12269()
+    closes = _closes(45)
+    for close in closes[:30]:
+        uninterrupted.update(close)
+
+    assert uninterrupted.macd_ready is True
+    assert uninterrupted.fully_ready is False
+
+    restored = Macd12269(state=uninterrupted.state)
+    expected = [uninterrupted.update(close) for close in closes[30:]]
+    actual = [restored.update(close) for close in closes[30:]]
+
+    assert actual == expected
+    assert restored.state == uninterrupted.state
+
+
+def test_checkpoint_restore_after_full_readiness_is_exact() -> None:
+    uninterrupted = Macd12269()
+    closes = _closes(50)
+    for close in closes[:40]:
+        uninterrupted.update(close)
+
+    assert uninterrupted.fully_ready is True
+
+    restored = Macd12269(state=uninterrupted.state)
+    expected = [uninterrupted.update(close) for close in closes[40:]]
+    actual = [restored.update(close) for close in closes[40:]]
+
+    assert actual == expected
+    assert restored.state == uninterrupted.state
+
+
+def test_invalid_input_and_corrupt_state_are_rejected() -> None:
+    macd = Macd12269()
+    with pytest.raises(TypeError, match="Decimal"):
+        macd.update(100.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="finite"):
+        macd.update(Decimal("NaN"))
+
+    state = macd.state
+    with pytest.raises(ValueError, match="sample count"):
+        MacdState(
+            samples=1,
+            fast_ema=state.fast_ema,
+            slow_ema=state.slow_ema,
+            signal_ema=state.signal_ema,
+        )


### PR DESCRIPTION
## What changed
Implements SF-023 under M2 using the recovered frozen Gate 1 MACD(12,26,9) numerical contract.

- Reuses the canonical `Ema` primitive for EMA12, EMA26, and signal EMA9
- First EMA12 at C11
- First EMA26 and MACD line at C25
- MACD remains available during C25..C32 while signal/histogram remain unavailable
- First signal seed uses exactly MACD25..MACD33
- First signal and histogram at C33
- Recursive signal EMA begins at C34
- Decimal arithmetic with no intermediate rounding
- Valid numeric zero remains distinct from unavailable values
- Immutable restart-safe `MacdState`
- Checkpoint validation ties signal EMA progress to valid MACD observation count
- Tests cover readiness boundaries, partial readiness, signal seed, histogram, zero values, recursion, invalid input, and recovery before/during/after full readiness

## Scope boundary
No combined IndicatorEngine orchestration, persistence layer, strategy evaluation, session policy, or external TA-library authority is introduced.

Closes #53 when merged.