### PR TITLE
SF-025 — Add Strategy V1 evaluation configuration

### DIFF
--- a/signalforge/config/strategy_v1.py
+++ b/signalforge/config/strategy_v1.py
@@ -1,0 +1,96 @@
+"""Typed configuration for the accepted intraday_momentum_v1 evaluator."""
+
+from datetime import time
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from signalforge.config.identity import ConfigIdentity, ConfigStatus, identify_config
+from signalforge.domain.provenance import StrategyIdentity
+
+
+class StrategyV1EvaluationConfig(BaseModel):
+    """Immutable Strategy V1 evaluation parameters and frozen comparison semantics."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    strategy_id: Literal["intraday_momentum_v1"] = "intraday_momentum_v1"
+    strategy_version: Literal["1.0.0"] = "1.0.0"
+
+    timeframe_minutes: int = Field(default=5, gt=0)
+    setup_ema_period: int = Field(default=9, gt=0)
+    trend_fast_ema_period: int = Field(default=20, gt=0)
+    trend_slow_ema_period: int = Field(default=50, gt=0)
+    rsi_period: int = Field(default=14, gt=0)
+    rsi_min: Decimal = Decimal("58")
+    rsi_max: Decimal = Decimal("65")
+    adx_period: int = Field(default=14, gt=0)
+    adx_threshold: Decimal = Decimal("22")
+    macd_fast_period: int = Field(default=12, gt=0)
+    macd_slow_period: int = Field(default=26, gt=0)
+    macd_signal_period: int = Field(default=9, gt=0)
+
+    minimum_warmup_candles: int = Field(default=250, ge=0)
+    first_signal_time_ist: time = time(9, 20)
+    last_signal_time_ist: time = time(15, 0)
+
+    rsi_lower_inclusive: Literal[True] = True
+    rsi_upper_inclusive: Literal[True] = True
+    adx_strictly_greater: Literal[True] = True
+    trend_strictly_greater: Literal[True] = True
+    setup_strictly_greater: Literal[True] = True
+    macd_diagnostic_only: Literal[True] = True
+
+    @model_validator(mode="after")
+    def validate_relationships(self) -> "StrategyV1EvaluationConfig":
+        if self.rsi_min > self.rsi_max:
+            raise ValueError("RSI minimum must not exceed RSI maximum")
+        if self.first_signal_time_ist > self.last_signal_time_ist:
+            raise ValueError("first signal time must not be after last signal time")
+        if self.trend_fast_ema_period >= self.trend_slow_ema_period:
+            raise ValueError("trend fast EMA period must be less than trend slow EMA period")
+        if self.macd_fast_period >= self.macd_slow_period:
+            raise ValueError("MACD fast period must be less than MACD slow period")
+        return self
+
+    @property
+    def strategy_identity(self) -> StrategyIdentity:
+        return StrategyIdentity(
+            strategy_id=self.strategy_id,
+            strategy_version=self.strategy_version,
+        )
+
+    def semantic_mapping(self) -> dict[str, object]:
+        """Return canonical hashable semantic content for config identity."""
+
+        return {
+            "strategy_id": self.strategy_id,
+            "strategy_version": self.strategy_version,
+            "timeframe_minutes": self.timeframe_minutes,
+            "setup_ema_period": self.setup_ema_period,
+            "trend_fast_ema_period": self.trend_fast_ema_period,
+            "trend_slow_ema_period": self.trend_slow_ema_period,
+            "rsi_period": self.rsi_period,
+            "rsi_min": self.rsi_min,
+            "rsi_max": self.rsi_max,
+            "rsi_lower_inclusive": self.rsi_lower_inclusive,
+            "rsi_upper_inclusive": self.rsi_upper_inclusive,
+            "adx_period": self.adx_period,
+            "adx_threshold": self.adx_threshold,
+            "adx_strictly_greater": self.adx_strictly_greater,
+            "macd_fast_period": self.macd_fast_period,
+            "macd_slow_period": self.macd_slow_period,
+            "macd_signal_period": self.macd_signal_period,
+            "macd_diagnostic_only": self.macd_diagnostic_only,
+            "trend_strictly_greater": self.trend_strictly_greater,
+            "setup_strictly_greater": self.setup_strictly_greater,
+            "minimum_warmup_candles": self.minimum_warmup_candles,
+            "first_signal_time_ist": self.first_signal_time_ist.isoformat(timespec="minutes"),
+            "last_signal_time_ist": self.last_signal_time_ist.isoformat(timespec="minutes"),
+        }
+
+    def identify(self, *, status: ConfigStatus = ConfigStatus.ACCEPTED) -> ConfigIdentity:
+        """Build canonical identity for this Strategy V1 configuration."""
+
+        return identify_config(self.semantic_mapping(), status=status)

--- a/tests/unit/config/test_strategy_v1.py
+++ b/tests/unit/config/test_strategy_v1.py
@@ -11,7 +11,6 @@ from signalforge.domain.provenance import StrategyIdentity
 
 def test_defaults_match_accepted_strategy_v1() -> None:
     config = StrategyV1EvaluationConfig()
-
     assert config.strategy_identity == StrategyIdentity("intraday_momentum_v1", "1.0.0")
     assert config.timeframe_minutes == 5
     assert config.setup_ema_period == 9
@@ -20,11 +19,7 @@ def test_defaults_match_accepted_strategy_v1() -> None:
     assert (config.rsi_min, config.rsi_max) == (Decimal("58"), Decimal("65"))
     assert config.adx_period == 14
     assert config.adx_threshold == Decimal("22")
-    assert (config.macd_fast_period, config.macd_slow_period, config.macd_signal_period) == (
-        12,
-        26,
-        9,
-    )
+    assert (config.macd_fast_period, config.macd_slow_period, config.macd_signal_period) == (12, 26, 9)
     assert config.minimum_warmup_candles == 250
     assert config.first_signal_time_ist == time(9, 20)
     assert config.last_signal_time_ist == time(15, 0)
@@ -32,7 +27,6 @@ def test_defaults_match_accepted_strategy_v1() -> None:
 
 def test_frozen_semantics_are_explicit_and_cannot_be_changed() -> None:
     config = StrategyV1EvaluationConfig()
-
     assert config.rsi_lower_inclusive is True
     assert config.rsi_upper_inclusive is True
     assert config.adx_strictly_greater is True
@@ -59,7 +53,6 @@ def test_unknown_fields_are_rejected_so_macd_cannot_become_gate() -> None:
 
 def test_configuration_is_immutable() -> None:
     config = StrategyV1EvaluationConfig()
-
     with pytest.raises(ValidationError):
         config.adx_threshold = Decimal("23")
 
@@ -81,7 +74,6 @@ def test_relationship_validation() -> None:
 def test_semantic_mapping_is_supported_by_canonical_hashing() -> None:
     config = StrategyV1EvaluationConfig()
     identity = config.identify()
-
     assert identity.status is ConfigStatus.ACCEPTED
     assert identity == identify_config(config.semantic_mapping(), status=ConfigStatus.ACCEPTED)
     assert identity.config_id.value == identity.config_hash
@@ -91,7 +83,6 @@ def test_semantic_mapping_is_supported_by_canonical_hashing() -> None:
 def test_same_semantics_produce_stable_identity() -> None:
     left = StrategyV1EvaluationConfig()
     right = StrategyV1EvaluationConfig.model_validate(left.model_dump())
-
     assert left.semantic_mapping() == right.semantic_mapping()
     assert left.identify() == right.identify()
 
@@ -99,14 +90,13 @@ def test_same_semantics_produce_stable_identity() -> None:
 def test_parameter_change_changes_config_identity_without_changing_strategy_identity() -> None:
     accepted = StrategyV1EvaluationConfig()
     experimental = StrategyV1EvaluationConfig(adx_threshold=Decimal("23"))
-
     assert accepted.strategy_identity == experimental.strategy_identity
     assert accepted.identify().config_hash != experimental.identify().config_hash
-    assert experimental.identify(status=ConfigStatus.EXPERIMENTAL).status is ConfigStatus.EXPERIMENTAL
+    identity = experimental.identify(status=ConfigStatus.EXPERIMENTAL)
+    assert identity.status is ConfigStatus.EXPERIMENTAL
 
 
 def test_time_values_are_canonicalized_as_minute_strings() -> None:
     mapping = StrategyV1EvaluationConfig().semantic_mapping()
-
     assert mapping["first_signal_time_ist"] == "09:20"
     assert mapping["last_signal_time_ist"] == "15:00"

--- a/tests/unit/config/test_strategy_v1.py
+++ b/tests/unit/config/test_strategy_v1.py
@@ -1,0 +1,112 @@
+from datetime import time
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from signalforge.config.identity import ConfigStatus, identify_config
+from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.provenance import StrategyIdentity
+
+
+def test_defaults_match_accepted_strategy_v1() -> None:
+    config = StrategyV1EvaluationConfig()
+
+    assert config.strategy_identity == StrategyIdentity("intraday_momentum_v1", "1.0.0")
+    assert config.timeframe_minutes == 5
+    assert config.setup_ema_period == 9
+    assert (config.trend_fast_ema_period, config.trend_slow_ema_period) == (20, 50)
+    assert config.rsi_period == 14
+    assert (config.rsi_min, config.rsi_max) == (Decimal("58"), Decimal("65"))
+    assert config.adx_period == 14
+    assert config.adx_threshold == Decimal("22")
+    assert (config.macd_fast_period, config.macd_slow_period, config.macd_signal_period) == (
+        12,
+        26,
+        9,
+    )
+    assert config.minimum_warmup_candles == 250
+    assert config.first_signal_time_ist == time(9, 20)
+    assert config.last_signal_time_ist == time(15, 0)
+
+
+def test_frozen_semantics_are_explicit_and_cannot_be_changed() -> None:
+    config = StrategyV1EvaluationConfig()
+
+    assert config.rsi_lower_inclusive is True
+    assert config.rsi_upper_inclusive is True
+    assert config.adx_strictly_greater is True
+    assert config.trend_strictly_greater is True
+    assert config.setup_strictly_greater is True
+    assert config.macd_diagnostic_only is True
+
+    for field in (
+        "rsi_lower_inclusive",
+        "rsi_upper_inclusive",
+        "adx_strictly_greater",
+        "trend_strictly_greater",
+        "setup_strictly_greater",
+        "macd_diagnostic_only",
+    ):
+        with pytest.raises(ValidationError):
+            StrategyV1EvaluationConfig(**{field: False})
+
+
+def test_unknown_fields_are_rejected_so_macd_cannot_become_gate() -> None:
+    with pytest.raises(ValidationError):
+        StrategyV1EvaluationConfig(macd_qualification_gate=True)  # type: ignore[call-arg]
+
+
+def test_configuration_is_immutable() -> None:
+    config = StrategyV1EvaluationConfig()
+
+    with pytest.raises(ValidationError):
+        config.adx_threshold = Decimal("23")
+
+
+def test_relationship_validation() -> None:
+    with pytest.raises(ValidationError, match="RSI minimum"):
+        StrategyV1EvaluationConfig(rsi_min=Decimal("66"), rsi_max=Decimal("65"))
+    with pytest.raises(ValidationError, match="first signal time"):
+        StrategyV1EvaluationConfig(
+            first_signal_time_ist=time(15, 5),
+            last_signal_time_ist=time(15, 0),
+        )
+    with pytest.raises(ValidationError, match="trend fast EMA"):
+        StrategyV1EvaluationConfig(trend_fast_ema_period=50, trend_slow_ema_period=20)
+    with pytest.raises(ValidationError, match="MACD fast period"):
+        StrategyV1EvaluationConfig(macd_fast_period=26, macd_slow_period=12)
+
+
+def test_semantic_mapping_is_supported_by_canonical_hashing() -> None:
+    config = StrategyV1EvaluationConfig()
+    identity = config.identify()
+
+    assert identity.status is ConfigStatus.ACCEPTED
+    assert identity == identify_config(config.semantic_mapping(), status=ConfigStatus.ACCEPTED)
+    assert identity.config_id.value == identity.config_hash
+    assert len(identity.config_hash) == 64
+
+
+def test_same_semantics_produce_stable_identity() -> None:
+    left = StrategyV1EvaluationConfig()
+    right = StrategyV1EvaluationConfig.model_validate(left.model_dump())
+
+    assert left.semantic_mapping() == right.semantic_mapping()
+    assert left.identify() == right.identify()
+
+
+def test_parameter_change_changes_config_identity_without_changing_strategy_identity() -> None:
+    accepted = StrategyV1EvaluationConfig()
+    experimental = StrategyV1EvaluationConfig(adx_threshold=Decimal("23"))
+
+    assert accepted.strategy_identity == experimental.strategy_identity
+    assert accepted.identify().config_hash != experimental.identify().config_hash
+    assert experimental.identify(status=ConfigStatus.EXPERIMENTAL).status is ConfigStatus.EXPERIMENTAL
+
+
+def test_time_values_are_canonicalized_as_minute_strings() -> None:
+    mapping = StrategyV1EvaluationConfig().semantic_mapping()
+
+    assert mapping["first_signal_time_ist"] == "09:20"
+    assert mapping["last_signal_time_ist"] == "15:00"

--- a/tests/unit/config/test_strategy_v1.py
+++ b/tests/unit/config/test_strategy_v1.py
@@ -19,7 +19,11 @@ def test_defaults_match_accepted_strategy_v1() -> None:
     assert (config.rsi_min, config.rsi_max) == (Decimal("58"), Decimal("65"))
     assert config.adx_period == 14
     assert config.adx_threshold == Decimal("22")
-    assert (config.macd_fast_period, config.macd_slow_period, config.macd_signal_period) == (12, 26, 9)
+    assert (
+        config.macd_fast_period,
+        config.macd_slow_period,
+        config.macd_signal_period,
+    ) == (12, 26, 9)
     assert config.minimum_warmup_candles == 250
     assert config.first_signal_time_ist == time(9, 20)
     assert config.last_signal_time_ist == time(15, 0)


### PR DESCRIPTION
## What changed
Implements SF-025, the typed immutable configuration boundary for `intraday_momentum_v1 / 1.0.0`.

- Adds frozen Pydantic StrategyV1EvaluationConfig
- Defaults exactly match accepted Gate 1 periods, thresholds, warm-up and signal window
- Freezes comparison semantics: RSI bounds inclusive; ADX/trend/setup strict; MACD diagnostic-only
- Exposes canonical semantic mapping compatible with existing config hashing/identity
- Preserves StrategyIdentity separately from parameter-derived ConfigIdentity
- Rejects unknown fields and invalid parameter relationships
- Tests immutability, frozen semantics, defaults, hash stability and parameter-change identity

## Scope boundary
No strategy evaluation logic, signal lifecycle, indicator changes, position sizing, ranking, short-side rules, or broker logic.

Closes #55 when merged.