### PR TITLE
SF-027 — Add Strategy V1 momentum evaluator

### DIFF
--- a/signalforge/runtime/momentum.py
+++ b/signalforge/runtime/momentum.py
@@ -1,0 +1,51 @@
+"""Isolated Strategy V1 momentum evaluation."""
+
+from __future__ import annotations
+
+from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.indicators import IndicatorSnapshot
+from signalforge.domain.strategy import MomentumResult
+
+
+def evaluate_momentum(
+    snapshot: IndicatorSnapshot,
+    config: StrategyV1EvaluationConfig,
+) -> MomentumResult:
+    """Evaluate the accepted RSI/ADX momentum rule with diagnostic MACD metadata."""
+
+    _require_supported_periods(config)
+
+    rsi_passed = (
+        snapshot.rsi14 is not None
+        and config.rsi_min <= snapshot.rsi14 <= config.rsi_max
+    )
+    adx_passed = (
+        snapshot.adx14 is not None
+        and snapshot.adx14 > config.adx_threshold
+    )
+
+    macd_signal_positive: bool | None
+    if snapshot.macd_signal is None:
+        macd_signal_positive = None
+    else:
+        macd_signal_positive = snapshot.macd_signal > 0
+
+    return MomentumResult(
+        passed=rsi_passed and adx_passed,
+        rsi_passed=rsi_passed,
+        adx_passed=adx_passed,
+        macd_signal_positive=macd_signal_positive,
+    )
+
+
+def _require_supported_periods(config: StrategyV1EvaluationConfig) -> None:
+    if config.rsi_period != 14:
+        raise ValueError("IndicatorSnapshot exposes only RSI(14)")
+    if config.adx_period != 14:
+        raise ValueError("IndicatorSnapshot exposes only ADX(14)")
+    if (
+        config.macd_fast_period,
+        config.macd_slow_period,
+        config.macd_signal_period,
+    ) != (12, 26, 9):
+        raise ValueError("IndicatorSnapshot exposes only MACD(12,26,9)")

--- a/tests/unit/runtime/test_momentum.py
+++ b/tests/unit/runtime/test_momentum.py
@@ -1,0 +1,118 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.indicators import IndicatorSnapshot
+from signalforge.domain.time import CandleInterval, IST
+from signalforge.runtime.momentum import evaluate_momentum
+
+
+def _snapshot(
+    *,
+    rsi14: Decimal | None = Decimal("60"),
+    adx14: Decimal | None = Decimal("23"),
+    macd_signal: Decimal | None = Decimal("1"),
+) -> IndicatorSnapshot:
+    start = datetime(2026, 8, 31, 10, 0, tzinfo=IST)
+    return IndicatorSnapshot(
+        instrument_id=InstrumentId("NSE:TEST"),
+        interval=CandleInterval(start=start, end=start + timedelta(minutes=5)),
+        ready=False,
+        calculation_version="test",
+        rsi14=rsi14,
+        adx14=adx14,
+        macd_signal=macd_signal,
+    )
+
+
+def test_rsi_bounds_are_inclusive() -> None:
+    config = StrategyV1EvaluationConfig()
+
+    assert evaluate_momentum(_snapshot(rsi14=Decimal("58")), config).passed is True
+    assert evaluate_momentum(_snapshot(rsi14=Decimal("65")), config).passed is True
+
+
+def test_rsi_outside_bounds_fails() -> None:
+    config = StrategyV1EvaluationConfig()
+
+    below = evaluate_momentum(_snapshot(rsi14=Decimal("57.999")), config)
+    above = evaluate_momentum(_snapshot(rsi14=Decimal("65.001")), config)
+
+    assert below.passed is False
+    assert below.rsi_passed is False
+    assert above.passed is False
+    assert above.rsi_passed is False
+
+
+def test_adx_threshold_is_strict() -> None:
+    config = StrategyV1EvaluationConfig()
+
+    at_threshold = evaluate_momentum(_snapshot(adx14=Decimal("22")), config)
+    above_threshold = evaluate_momentum(_snapshot(adx14=Decimal("22.0001")), config)
+
+    assert at_threshold.passed is False
+    assert at_threshold.adx_passed is False
+    assert above_threshold.passed is True
+    assert above_threshold.adx_passed is True
+
+
+@pytest.mark.parametrize(
+    ("macd_signal", "expected"),
+    [
+        (Decimal("1"), True),
+        (Decimal("0"), False),
+        (Decimal("-1"), False),
+        (None, None),
+    ],
+)
+def test_macd_is_diagnostic_only(
+    macd_signal: Decimal | None,
+    expected: bool | None,
+) -> None:
+    result = evaluate_momentum(_snapshot(macd_signal=macd_signal), StrategyV1EvaluationConfig())
+
+    assert result.passed is True
+    assert result.macd_signal_positive is expected
+
+
+def test_unavailable_required_indicators_cannot_pass() -> None:
+    config = StrategyV1EvaluationConfig()
+
+    missing_rsi = evaluate_momentum(_snapshot(rsi14=None), config)
+    missing_adx = evaluate_momentum(_snapshot(adx14=None), config)
+
+    assert missing_rsi.passed is False
+    assert missing_rsi.rsi_passed is False
+    assert missing_rsi.adx_passed is True
+    assert missing_adx.passed is False
+    assert missing_adx.rsi_passed is True
+    assert missing_adx.adx_passed is False
+
+
+def test_overall_snapshot_readiness_does_not_suppress_available_momentum_inputs() -> None:
+    result = evaluate_momentum(_snapshot(), StrategyV1EvaluationConfig())
+
+    assert result.passed is True
+
+
+def test_identical_inputs_are_deterministic() -> None:
+    snapshot = _snapshot()
+    config = StrategyV1EvaluationConfig()
+
+    assert evaluate_momentum(snapshot, config) == evaluate_momentum(snapshot, config)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        StrategyV1EvaluationConfig(rsi_period=13),
+        StrategyV1EvaluationConfig(adx_period=13),
+        StrategyV1EvaluationConfig(macd_fast_period=11),
+    ],
+)
+def test_unsupported_indicator_periods_fail_fast(config: StrategyV1EvaluationConfig) -> None:
+    with pytest.raises(ValueError, match="IndicatorSnapshot exposes only"):
+        evaluate_momentum(_snapshot(), config)

--- a/tests/unit/runtime/test_momentum.py
+++ b/tests/unit/runtime/test_momentum.py
@@ -6,7 +6,7 @@ import pytest
 from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
 from signalforge.domain.ids import InstrumentId
 from signalforge.domain.indicators import IndicatorSnapshot
-from signalforge.domain.time import CandleInterval, IST
+from signalforge.domain.time import IST, CandleInterval
 from signalforge.runtime.momentum import evaluate_momentum
 
 


### PR DESCRIPTION
## What changed
Implements SF-027, the isolated Strategy V1 momentum component.

- Evaluates RSI(14) in [58,65] inclusive
- Evaluates ADX(14) > 22 strictly
- Momentum passes iff RSI and ADX both pass
- MACD signal positivity is diagnostic only and cannot affect momentum pass/fail
- Unavailable RSI/ADX explicitly fail their required component; unavailable MACD remains diagnostic absence
- Uses canonical unrounded Decimal values
- Keeps overall IndicatorSnapshot readiness out of the isolated Momentum component
- Fails fast when experimental indicator periods cannot be represented by the fixed snapshot contract
- Tests exact boundaries, MACD diagnostic independence, unavailable inputs, determinism, and unsupported periods

## Scope boundary
No trend, setup, timing/warm-up, actionability, Signal lifecycle, execution, or broker logic.

Closes #57 when merged.