### PR TITLE
SF-030 — Add composite StrategyEvaluator

### DIFF
--- a/signalforge/runtime/strategy_evaluator.py
+++ b/signalforge/runtime/strategy_evaluator.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
 from signalforge.domain.indicators import IndicatorSnapshot
 from signalforge.domain.market import CompletedCandle
-from signalforge.domain.strategy import StrategyEvaluation
+from signalforge.domain.strategy import DecisionReason, StrategyEvaluation
 from signalforge.runtime.eligibility import (
     EvaluationGuardResult,
     MarketDataFeedState,
@@ -38,7 +38,9 @@ class StrategyEvaluatorResult:
     def __post_init__(self) -> None:
         expected_actionable = self.evaluation.qualified and self.guard.actionable
         if self.evaluation.actionable != expected_actionable:
-            raise ValueError("StrategyEvaluation actionability must equal qualified AND guard actionable")
+            raise ValueError(
+                "StrategyEvaluation actionability must equal qualified AND guard actionable"
+            )
 
 
 class StrategyEvaluator:
@@ -75,7 +77,12 @@ class StrategyEvaluator:
             setup=setup,
             qualified=qualified,
             actionable=qualified and guard.actionable,
-            reasons=_decision_reasons(trend.passed, momentum.passed, setup.passed, guard.actionable),
+            reasons=_decision_reasons(
+                trend.passed,
+                momentum.passed,
+                setup.passed,
+                guard.actionable,
+            ),
         )
         return StrategyEvaluatorResult(evaluation=evaluation, guard=guard)
 
@@ -85,10 +92,8 @@ def _decision_reasons(
     momentum_passed: bool,
     setup_passed: bool,
     guard_actionable: bool,
-):
-    """Build reasons by constructing through the StrategyEvaluation domain contract."""
-
-    from signalforge.domain.strategy import DecisionReason
+) -> tuple[DecisionReason, ...]:
+    """Return the existing domain reason ordering for the composed decision."""
 
     qualified = trend_passed and momentum_passed and setup_passed
     if qualified:

--- a/signalforge/runtime/strategy_evaluator.py
+++ b/signalforge/runtime/strategy_evaluator.py
@@ -1,0 +1,106 @@
+"""Composite Strategy V1 evaluator over canonical candle and indicator facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.indicators import IndicatorSnapshot
+from signalforge.domain.market import CompletedCandle
+from signalforge.domain.strategy import StrategyEvaluation
+from signalforge.runtime.eligibility import (
+    EvaluationGuardResult,
+    MarketDataFeedState,
+    evaluate_guard,
+)
+from signalforge.runtime.indicators import IndicatorContinuity
+from signalforge.runtime.momentum import evaluate_momentum
+from signalforge.runtime.setup import evaluate_setup
+from signalforge.runtime.trend import evaluate_trend
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyEvaluationContext:
+    """Non-qualification context required to decide evaluation actionability."""
+
+    completed_regular_session_candles: int
+    continuity: IndicatorContinuity
+    feed_state: MarketDataFeedState | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyEvaluatorResult:
+    """Canonical strategy decision plus its explicit eligibility/actionability guard result."""
+
+    evaluation: StrategyEvaluation
+    guard: EvaluationGuardResult
+
+    def __post_init__(self) -> None:
+        expected_actionable = self.evaluation.qualified and self.guard.actionable
+        if self.evaluation.actionable != expected_actionable:
+            raise ValueError("StrategyEvaluation actionability must equal qualified AND guard actionable")
+
+
+class StrategyEvaluator:
+    """Broker-independent Strategy V1 evaluator."""
+
+    def __init__(self, config: StrategyV1EvaluationConfig) -> None:
+        self.config = config
+
+    def evaluate(
+        self,
+        candle: CompletedCandle,
+        snapshot: IndicatorSnapshot,
+        context: StrategyEvaluationContext,
+    ) -> StrategyEvaluatorResult:
+        """Compose guard, trend, momentum, and setup into one immutable decision."""
+
+        guard = evaluate_guard(
+            candle,
+            snapshot,
+            self.config,
+            completed_regular_session_candles=context.completed_regular_session_candles,
+            continuity=context.continuity,
+            feed_state=context.feed_state,
+        )
+        trend = evaluate_trend(snapshot, self.config)
+        momentum = evaluate_momentum(snapshot, self.config)
+        setup = evaluate_setup(candle, snapshot, self.config)
+        qualified = trend.passed and momentum.passed and setup.passed
+        evaluation = StrategyEvaluation(
+            instrument_id=candle.instrument_id,
+            interval=candle.interval,
+            trend=trend,
+            momentum=momentum,
+            setup=setup,
+            qualified=qualified,
+            actionable=qualified and guard.actionable,
+            reasons=_decision_reasons(trend.passed, momentum.passed, setup.passed, guard.actionable),
+        )
+        return StrategyEvaluatorResult(evaluation=evaluation, guard=guard)
+
+
+def _decision_reasons(
+    trend_passed: bool,
+    momentum_passed: bool,
+    setup_passed: bool,
+    guard_actionable: bool,
+):
+    """Build reasons by constructing through the StrategyEvaluation domain contract."""
+
+    from signalforge.domain.strategy import DecisionReason
+
+    qualified = trend_passed and momentum_passed and setup_passed
+    if qualified:
+        if guard_actionable:
+            return (DecisionReason.QUALIFIED, DecisionReason.ACTIONABLE)
+        return (DecisionReason.QUALIFIED, DecisionReason.QUALIFIED_NOT_ACTIONABLE)
+
+    reasons: list[DecisionReason] = []
+    if not trend_passed:
+        reasons.append(DecisionReason.TREND_NOT_MET)
+    if not momentum_passed:
+        reasons.append(DecisionReason.MOMENTUM_NOT_MET)
+    if not setup_passed:
+        reasons.append(DecisionReason.SETUP_NOT_MET)
+    return tuple(reasons)

--- a/tests/unit/runtime/test_strategy_evaluator.py
+++ b/tests/unit/runtime/test_strategy_evaluator.py
@@ -1,0 +1,199 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.indicators import IndicatorSnapshot
+from signalforge.domain.market import CandleQuality, CompletedCandle
+from signalforge.domain.money import Price
+from signalforge.domain.strategy import DecisionReason
+from signalforge.domain.time import IST, CandleInterval
+from signalforge.runtime.eligibility import EvaluationGuardReason, MarketDataFeedState
+from signalforge.runtime.indicators import IndicatorContinuity
+from signalforge.runtime.strategy_evaluator import (
+    StrategyEvaluationContext,
+    StrategyEvaluator,
+)
+
+INSTRUMENT = InstrumentId("NSE:TEST")
+
+
+def _interval(*, end_hour: int = 10, end_minute: int = 0) -> CandleInterval:
+    end = datetime(2026, 8, 31, end_hour, end_minute, tzinfo=IST)
+    return CandleInterval(start=end - timedelta(minutes=5), end=end)
+
+
+def _candle(*, close: str = "101", interval: CandleInterval | None = None) -> CompletedCandle:
+    interval = interval or _interval()
+    return CompletedCandle(
+        instrument_id=INSTRUMENT,
+        interval=interval,
+        quality=CandleQuality.VALID,
+        open=Price(Decimal("100")),
+        high=Price(Decimal("102")),
+        low=Price(Decimal("99")),
+        close=Price(Decimal(close)),
+        volume=100,
+        source="test",
+        source_event_count=4,
+    )
+
+
+def _snapshot(
+    *,
+    interval: CandleInterval | None = None,
+    ema9: str = "100",
+    ema20: str = "101",
+    ema50: str = "100",
+    rsi14: str = "60",
+    adx14: str = "23",
+    macd_signal: str | None = "1",
+) -> IndicatorSnapshot:
+    interval = interval or _interval()
+    signal = Decimal(macd_signal) if macd_signal is not None else None
+    return IndicatorSnapshot(
+        instrument_id=INSTRUMENT,
+        interval=interval,
+        ready=True,
+        calculation_version="test",
+        ema9=Decimal(ema9),
+        ema20=Decimal(ema20),
+        ema50=Decimal(ema50),
+        rsi14=Decimal(rsi14),
+        adx14=Decimal(adx14),
+        macd_line=Decimal("2"),
+        macd_signal=signal,
+        macd_histogram=Decimal("1") if signal is not None else None,
+    )
+
+
+def _context(
+    *,
+    warmup: int = 250,
+    feed_state: MarketDataFeedState | None = MarketDataFeedState.HEALTHY,
+) -> StrategyEvaluationContext:
+    return StrategyEvaluationContext(
+        completed_regular_session_candles=warmup,
+        continuity=IndicatorContinuity.HEALTHY,
+        feed_state=feed_state,
+    )
+
+
+def test_all_components_pass_and_guard_actionable() -> None:
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    result = evaluator.evaluate(_candle(), _snapshot(), _context())
+
+    assert result.evaluation.qualified is True
+    assert result.evaluation.actionable is True
+    assert result.evaluation.reasons == (
+        DecisionReason.QUALIFIED,
+        DecisionReason.ACTIONABLE,
+    )
+    assert result.guard.reasons == ()
+
+
+def test_qualified_but_outside_signal_window_is_not_actionable() -> None:
+    interval = _interval(end_hour=15, end_minute=5)
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    result = evaluator.evaluate(
+        _candle(interval=interval),
+        _snapshot(interval=interval),
+        _context(),
+    )
+
+    assert result.evaluation.qualified is True
+    assert result.evaluation.actionable is False
+    assert result.evaluation.reasons == (
+        DecisionReason.QUALIFIED,
+        DecisionReason.QUALIFIED_NOT_ACTIONABLE,
+    )
+    assert result.guard.reasons == (EvaluationGuardReason.OUTSIDE_SIGNAL_WINDOW,)
+
+
+def test_qualified_but_stale_feed_is_not_actionable() -> None:
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    result = evaluator.evaluate(
+        _candle(),
+        _snapshot(),
+        _context(feed_state=MarketDataFeedState.STALE),
+    )
+
+    assert result.evaluation.qualified is True
+    assert result.evaluation.actionable is False
+    assert result.guard.reasons == (EvaluationGuardReason.FEED_NOT_HEALTHY,)
+
+
+def test_trend_failure_reason_is_preserved() -> None:
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    result = evaluator.evaluate(_candle(), _snapshot(ema20="100", ema50="100"), _context())
+
+    assert result.evaluation.qualified is False
+    assert result.evaluation.actionable is False
+    assert result.evaluation.reasons == (DecisionReason.TREND_NOT_MET,)
+
+
+def test_momentum_failure_reason_is_preserved() -> None:
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    result = evaluator.evaluate(_candle(), _snapshot(rsi14="57.9"), _context())
+
+    assert result.evaluation.reasons == (DecisionReason.MOMENTUM_NOT_MET,)
+
+
+def test_setup_failure_reason_is_preserved() -> None:
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    result = evaluator.evaluate(_candle(close="100"), _snapshot(ema9="100"), _context())
+
+    assert result.evaluation.reasons == (DecisionReason.SETUP_NOT_MET,)
+
+
+def test_multiple_failure_reasons_have_deterministic_domain_order() -> None:
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    result = evaluator.evaluate(
+        _candle(close="100"),
+        _snapshot(ema9="100", ema20="99", ema50="100", rsi14="57"),
+        _context(),
+    )
+
+    assert result.evaluation.reasons == (
+        DecisionReason.TREND_NOT_MET,
+        DecisionReason.MOMENTUM_NOT_MET,
+        DecisionReason.SETUP_NOT_MET,
+    )
+
+
+def test_macd_diagnostic_never_changes_qualification_or_actionability() -> None:
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+
+    positive = evaluator.evaluate(_candle(), _snapshot(macd_signal="1"), _context())
+    negative = evaluator.evaluate(_candle(), _snapshot(macd_signal="-1"), _context())
+
+    assert positive.evaluation.qualified is True
+    assert negative.evaluation.qualified is True
+    assert positive.evaluation.actionable is True
+    assert negative.evaluation.actionable is True
+    assert positive.evaluation.momentum.macd_signal_positive is True
+    assert negative.evaluation.momentum.macd_signal_positive is False
+
+
+def test_identical_inputs_produce_identical_output() -> None:
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    candle = _candle()
+    snapshot = _snapshot()
+    context = _context()
+
+    assert evaluator.evaluate(candle, snapshot, context) == evaluator.evaluate(
+        candle, snapshot, context
+    )
+
+
+def test_insufficient_warmup_retains_qualification_but_blocks_actionability() -> None:
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    result = evaluator.evaluate(_candle(), _snapshot(), _context(warmup=249))
+
+    assert result.evaluation.qualified is True
+    assert result.evaluation.actionable is False
+    assert result.evaluation.reasons == (
+        DecisionReason.QUALIFIED,
+        DecisionReason.QUALIFIED_NOT_ACTIONABLE,
+    )
+    assert result.guard.reasons == (EvaluationGuardReason.INSUFFICIENT_WARMUP,)


### PR DESCRIPTION
## What changed
Implements SF-030, the broker-independent Strategy V1 composite evaluator.

- Composes SF-029 guard with Trend, Momentum, and Setup components
- Produces the existing immutable `StrategyEvaluation` domain fact
- Preserves qualification truth independently from actionability
- Exposes the explicit `EvaluationGuardResult` alongside the domain evaluation so operational rejection reasons remain auditable without overloading `DecisionReason`
- `qualified = trend AND momentum AND setup`
- `actionable = qualified AND guard.actionable`
- MACD remains diagnostic-only and cannot affect qualification/actionability
- Tests qualified/actionable, qualified-not-actionable, each component failure, deterministic reason ordering, MACD diagnostic independence, determinism, and warm-up blocking

## Scope boundary
No Signal creation, ARMED lifecycle, trigger, execution, broker types, or intra-candle logic.

Closes #60 when merged.