### PR TITLE
SF-032 — Add actionable signal arming lifecycle

### DIFF
--- a/signalforge/runtime/signal_lifecycle.py
+++ b/signalforge/runtime/signal_lifecycle.py
@@ -1,0 +1,112 @@
+"""Signal creation and initial ARMED lifecycle for Strategy V1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from decimal import Decimal
+
+from signalforge.domain.armed import ArmedSetup, ArmedSetupState
+from signalforge.domain.instruments import TickSizeSchedule
+from signalforge.domain.market import CompletedCandle
+from signalforge.domain.money import Price, ceil_to_tick
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.time import IST
+from signalforge.runtime.strategy_evaluator import StrategyEvaluatorResult
+
+_ENTRY_OFFSET = Decimal("1.001")
+
+
+@dataclass(frozen=True, slots=True)
+class SignalArmingResult:
+    """Immutable facts produced by one successful actionable evaluation."""
+
+    signal: Signal
+    armed_setup: ArmedSetup
+
+    def __post_init__(self) -> None:
+        if self.armed_setup.signal_id != self.signal.signal_id:
+            raise ValueError("ArmedSetup must belong to the produced Signal")
+        if self.armed_setup.signal_low != self.signal.signal_low:
+            raise ValueError("ArmedSetup signal_low must match the produced Signal")
+
+
+class SignalLifecycleManager:
+    """Own Signal creation and the current single-security ARMED lifecycle."""
+
+    def __init__(self, *, run: RunIdentity, tick_schedule: TickSizeSchedule) -> None:
+        self.run = run
+        self.tick_schedule = tick_schedule
+        self._active: SignalArmingResult | None = None
+
+    @property
+    def active(self) -> SignalArmingResult | None:
+        return self._active
+
+    def arm_if_actionable(
+        self,
+        candle: CompletedCandle,
+        evaluator_result: StrategyEvaluatorResult,
+        *,
+        open_position: bool = False,
+    ) -> SignalArmingResult | None:
+        """Create one Signal + ARMED setup when the evaluation is actionable.
+
+        Reprocessing the same logical evaluation while its setup remains ARMED is
+        idempotent and returns the existing facts. A different actionable evaluation
+        is blocked while another setup is ARMED or while an OPEN position exists.
+        """
+
+        evaluation = evaluator_result.evaluation
+        if candle.instrument_id != evaluation.instrument_id:
+            raise ValueError("Candle and StrategyEvaluation instruments must match")
+        if candle.interval != evaluation.interval:
+            raise ValueError("Candle and StrategyEvaluation intervals must match")
+        if self.tick_schedule.instrument_id != candle.instrument_id:
+            raise ValueError("TickSizeSchedule instrument must match the signal candle")
+
+        if not evaluation.actionable:
+            return None
+        if candle.close is None or candle.low is None:
+            raise ValueError("Actionable evaluation requires signal candle close and low")
+
+        candidate = self._build_result(candle)
+
+        if open_position:
+            return None
+        if self._active is not None and self._active.armed_setup.state is ArmedSetupState.ARMED:
+            if self._active.signal.signal_id == candidate.signal.signal_id:
+                return self._active
+            return None
+
+        self._active = candidate
+        return candidate
+
+    def _build_result(self, candle: CompletedCandle) -> SignalArmingResult:
+        assert candle.close is not None
+        assert candle.low is not None
+
+        created_at = candle.interval.end
+        signal = Signal.create(
+            instrument_id=candle.instrument_id,
+            interval=candle.interval,
+            signal_close=candle.close,
+            signal_low=candle.low,
+            run=self.run,
+            created_at=created_at,
+        )
+
+        raw_trigger = Price(candle.close.value * _ENTRY_OFFSET)
+        trading_date = candle.interval.end.astimezone(IST).date()
+        tick_size = self.tick_schedule.tick_size_on(trading_date)
+        tradable_trigger = ceil_to_tick(raw_trigger, tick_size)
+        armed_setup = ArmedSetup(
+            signal_id=signal.signal_id,
+            raw_trigger=raw_trigger,
+            tradable_trigger=tradable_trigger,
+            signal_low=candle.low,
+            armed_at=created_at,
+            valid_until=created_at + timedelta(minutes=5),
+        )
+        return SignalArmingResult(signal=signal, armed_setup=armed_setup)

--- a/signalforge/runtime/signal_lifecycle.py
+++ b/signalforge/runtime/signal_lifecycle.py
@@ -65,16 +65,16 @@ class SignalLifecycleManager:
             raise ValueError("Candle and StrategyEvaluation intervals must match")
         if self.tick_schedule.instrument_id != candle.instrument_id:
             raise ValueError("TickSizeSchedule instrument must match the signal candle")
+        if not isinstance(open_position, bool):
+            raise TypeError("open_position must be a boolean")
 
-        if not evaluation.actionable:
+        if not evaluation.actionable or open_position:
             return None
         if candle.close is None or candle.low is None:
             raise ValueError("Actionable evaluation requires signal candle close and low")
 
         candidate = self._build_result(candle)
 
-        if open_position:
-            return None
         if self._active is not None and self._active.armed_setup.state is ArmedSetupState.ARMED:
             if self._active.signal.signal_id == candidate.signal.signal_id:
                 return self._active

--- a/tests/unit/runtime/test_signal_lifecycle.py
+++ b/tests/unit/runtime/test_signal_lifecycle.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.ids import ConfigId, InstrumentId, RunId
+from signalforge.domain.indicators import IndicatorSnapshot
+from signalforge.domain.instruments import TickSizeRule, TickSizeSchedule
+from signalforge.domain.market import CandleQuality, CompletedCandle
+from signalforge.domain.money import Price
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.time import IST, CandleInterval
+from signalforge.runtime.eligibility import MarketDataFeedState
+from signalforge.runtime.indicators import IndicatorContinuity
+from signalforge.runtime.signal_lifecycle import SignalLifecycleManager
+from signalforge.runtime.strategy_evaluator import (
+    StrategyEvaluationContext,
+    StrategyEvaluator,
+)
+
+INSTRUMENT = InstrumentId("NSE:RELIANCE")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-001"),
+        config_hash="abc123",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _interval(*, end_hour: int = 10, end_minute: int = 0) -> CandleInterval:
+    end = datetime(2026, 8, 31, end_hour, end_minute, tzinfo=IST)
+    return CandleInterval(start=end - timedelta(minutes=5), end=end)
+
+
+def _candle(
+    *,
+    interval: CandleInterval | None = None,
+    close: str = "100.11",
+    low: str = "99.00",
+) -> CompletedCandle:
+    interval = interval or _interval()
+    return CompletedCandle(
+        instrument_id=INSTRUMENT,
+        interval=interval,
+        quality=CandleQuality.VALID,
+        open=Price(Decimal("100")),
+        high=Price(Decimal("102")),
+        low=Price(Decimal(low)),
+        close=Price(Decimal(close)),
+        volume=100,
+        source="test",
+        source_event_count=4,
+    )
+
+
+def _snapshot(candle: CompletedCandle, *, rsi14: str = "60") -> IndicatorSnapshot:
+    return IndicatorSnapshot(
+        instrument_id=candle.instrument_id,
+        interval=candle.interval,
+        ready=True,
+        calculation_version="engine-v1",
+        ema9=Decimal("99"),
+        ema20=Decimal("101"),
+        ema50=Decimal("100"),
+        rsi14=Decimal(rsi14),
+        adx14=Decimal("23"),
+        macd_line=Decimal("1"),
+        macd_signal=Decimal("0.5"),
+        macd_histogram=Decimal("0.5"),
+    )
+
+
+def _evaluation(candle: CompletedCandle, *, rsi14: str = "60"):
+    evaluator = StrategyEvaluator(StrategyV1EvaluationConfig())
+    return evaluator.evaluate(
+        candle,
+        _snapshot(candle, rsi14=rsi14),
+        StrategyEvaluationContext(
+            completed_regular_session_candles=250,
+            continuity=IndicatorContinuity.HEALTHY,
+            feed_state=MarketDataFeedState.HEALTHY,
+        ),
+    )
+
+
+def _schedule() -> TickSizeSchedule:
+    return TickSizeSchedule(
+        instrument_id=INSTRUMENT,
+        rules=(
+            TickSizeRule(
+                tick_size=Price(Decimal("0.05")),
+                effective_from=date(2026, 1, 1),
+                effective_to=date(2026, 8, 30),
+            ),
+            TickSizeRule(
+                tick_size=Price(Decimal("0.10")),
+                effective_from=date(2026, 8, 31),
+            ),
+        ),
+    )
+
+
+def test_actionable_evaluation_creates_signal_and_immediately_arms_setup() -> None:
+    candle = _candle()
+    manager = SignalLifecycleManager(run=_run(), tick_schedule=_schedule())
+
+    result = manager.arm_if_actionable(candle, _evaluation(candle))
+
+    assert result is not None
+    assert manager.active is result
+    assert result.signal.instrument_id == INSTRUMENT
+    assert result.signal.interval == candle.interval
+    assert result.signal.signal_close == Price(Decimal("100.11"))
+    assert result.signal.signal_low == Price(Decimal("99.00"))
+    assert result.signal.run == _run()
+    assert result.signal.created_at == candle.interval.end
+    assert result.armed_setup.armed_at == candle.interval.end
+    assert result.armed_setup.valid_until == candle.interval.end + timedelta(minutes=5)
+
+
+def test_raw_trigger_is_exact_point_one_percent_and_tradable_trigger_ceil_to_tick() -> None:
+    candle = _candle(close="100.11")
+    manager = SignalLifecycleManager(run=_run(), tick_schedule=_schedule())
+
+    result = manager.arm_if_actionable(candle, _evaluation(candle))
+
+    assert result is not None
+    assert result.armed_setup.raw_trigger == Price(Decimal("100.21011"))
+    assert result.armed_setup.tradable_trigger == Price(Decimal("100.30"))
+    assert result.armed_setup.signal_low == Price(Decimal("99.00"))
+
+
+def test_effective_dated_tick_rule_is_resolved_from_signal_trading_date() -> None:
+    interval = CandleInterval(
+        start=datetime(2026, 8, 30, 9, 55, tzinfo=IST),
+        end=datetime(2026, 8, 30, 10, 0, tzinfo=IST),
+    )
+    candle = _candle(interval=interval, close="100.11")
+    manager = SignalLifecycleManager(run=_run(), tick_schedule=_schedule())
+
+    result = manager.arm_if_actionable(candle, _evaluation(candle))
+
+    assert result is not None
+    assert result.armed_setup.raw_trigger == Price(Decimal("100.21011"))
+    assert result.armed_setup.tradable_trigger == Price(Decimal("100.25"))
+
+
+def test_duplicate_processing_returns_same_logical_facts() -> None:
+    candle = _candle()
+    evaluation = _evaluation(candle)
+    manager = SignalLifecycleManager(run=_run(), tick_schedule=_schedule())
+
+    first = manager.arm_if_actionable(candle, evaluation)
+    second = manager.arm_if_actionable(candle, evaluation)
+
+    assert first is not None
+    assert second is first
+    assert manager.active is first
+
+
+def test_existing_armed_setup_blocks_different_actionable_evaluation() -> None:
+    first_candle = _candle()
+    next_interval = CandleInterval(
+        start=first_candle.interval.end,
+        end=first_candle.interval.end + timedelta(minutes=5),
+    )
+    second_candle = _candle(interval=next_interval, close="101.00", low="100.00")
+    manager = SignalLifecycleManager(run=_run(), tick_schedule=_schedule())
+
+    first = manager.arm_if_actionable(first_candle, _evaluation(first_candle))
+    second = manager.arm_if_actionable(second_candle, _evaluation(second_candle))
+
+    assert first is not None
+    assert second is None
+    assert manager.active is first
+
+
+def test_open_position_blocks_new_actionable_setup() -> None:
+    candle = _candle()
+    manager = SignalLifecycleManager(run=_run(), tick_schedule=_schedule())
+
+    result = manager.arm_if_actionable(candle, _evaluation(candle), open_position=True)
+
+    assert result is None
+    assert manager.active is None
+
+
+def test_non_actionable_evaluation_creates_no_lifecycle_facts() -> None:
+    candle = _candle()
+    manager = SignalLifecycleManager(run=_run(), tick_schedule=_schedule())
+
+    result = manager.arm_if_actionable(candle, _evaluation(candle, rsi14="57"))
+
+    assert result is None
+    assert manager.active is None
+
+
+def test_tick_schedule_instrument_mismatch_is_rejected() -> None:
+    candle = _candle()
+    schedule = TickSizeSchedule(
+        instrument_id=InstrumentId("NSE:TCS"),
+        rules=(
+            TickSizeRule(
+                tick_size=Price(Decimal("0.05")),
+                effective_from=date(2026, 1, 1),
+            ),
+        ),
+    )
+    manager = SignalLifecycleManager(run=_run(), tick_schedule=schedule)
+
+    try:
+        manager.arm_if_actionable(candle, _evaluation(candle))
+    except ValueError as exc:
+        assert "TickSizeSchedule instrument" in str(exc)
+    else:
+        raise AssertionError("Expected mismatched tick schedule to be rejected")


### PR DESCRIPTION
## What changed
Implements SF-032, the initial M4 SignalLifecycleManager boundary.

- Converts only actionable StrategyEvaluation results into Signal + ARMED setup facts
- Uses deterministic existing Signal identity/provenance
- Raw trigger = signal close * 1.001 using Decimal arithmetic
- Tradable trigger uses effective-dated TickSizeSchedule and ceil-to-tick normalization
- Retains signal-candle low as stop anchor
- Arms immediately at completed candle end and sets validity through the immediately following 5-minute candle
- Duplicate processing of the same logical evaluation while ARMED returns the same facts
- Blocks a different actionable setup while another ARMED setup exists
- Blocks all new lifecycle creation while an OPEN position is reported
- No trigger crossing, fills, Trade/Position opening, exits, or position sizing

Closes #63 when merged.