### PR TITLE
SF-034 — Add paper ExecutionPort

### DIFF
--- a/signalforge/runtime/execution.py
+++ b/signalforge/runtime/execution.py
@@ -1,0 +1,72 @@
+"""Broker-independent paper execution from accepted trigger evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, TriggerEvent
+from signalforge.domain.money import Quantity
+
+
+@dataclass(frozen=True, slots=True)
+class PaperExecutionResult:
+    """Immutable intent/fill facts produced from one accepted trigger event."""
+
+    entry_intent: EntryIntent
+    fill: Fill
+
+    def __post_init__(self) -> None:
+        if self.entry_intent.execution_mode is not ExecutionMode.PAPER:
+            raise ValueError("PaperExecutionResult requires PAPER EntryIntent")
+        if self.fill.execution_mode is not ExecutionMode.PAPER:
+            raise ValueError("PaperExecutionResult requires PAPER Fill")
+        if self.fill.entry_intent_id != self.entry_intent.entry_intent_id:
+            raise ValueError("Fill must belong to the produced EntryIntent")
+        if self.fill.trigger_event_id != self.entry_intent.trigger_event_id:
+            raise ValueError("Fill and EntryIntent must reference the same TriggerEvent")
+
+
+class PaperExecutionPort:
+    """Deterministic in-memory PAPER implementation of the execution boundary."""
+
+    def __init__(self) -> None:
+        self._results: dict[str, PaperExecutionResult] = {}
+
+    def execute(self, trigger_event: TriggerEvent, *, quantity: Quantity) -> PaperExecutionResult:
+        """Create a PAPER intent/fill using the trigger's actual observed price.
+
+        Reprocessing the same logical execution request returns the existing immutable
+        facts. The configured/reference trigger price is retained as reference data;
+        the simulated fill uses the actual observed eligible trigger-crossing price.
+        """
+
+        entry_intent = EntryIntent.create(
+            trigger_event_id=trigger_event.trigger_event_id,
+            signal_id=trigger_event.signal_id,
+            instrument_id=trigger_event.instrument_id,
+            reference_price=trigger_event.reference_price,
+            quantity=quantity,
+            execution_mode=ExecutionMode.PAPER,
+            created_at=trigger_event.observed_at,
+            run=trigger_event.run,
+        )
+        key = str(entry_intent.entry_intent_id)
+        existing = self._results.get(key)
+        if existing is not None:
+            return existing
+
+        fill = Fill.create(
+            entry_intent_id=entry_intent.entry_intent_id,
+            trigger_event_id=trigger_event.trigger_event_id,
+            signal_id=trigger_event.signal_id,
+            instrument_id=trigger_event.instrument_id,
+            reference_price=trigger_event.reference_price,
+            fill_price=trigger_event.observed_price,
+            quantity=quantity,
+            execution_mode=ExecutionMode.PAPER,
+            filled_at=trigger_event.observed_at,
+            run=trigger_event.run,
+        )
+        result = PaperExecutionResult(entry_intent=entry_intent, fill=fill)
+        self._results[key] = result
+        return result

--- a/tests/unit/runtime/test_execution_port.py
+++ b/tests/unit/runtime/test_execution_port.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from signalforge.domain.execution import ExecutionMode, TriggerEvent
+from signalforge.domain.ids import ConfigId, InstrumentId, RunId, SignalId
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.time import IST
+from signalforge.runtime.execution import PaperExecutionPort
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-001"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-001"),
+        config_hash="abc123",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _trigger(
+    *,
+    reference: str = "100.10",
+    observed: str = "100.10",
+) -> TriggerEvent:
+    return TriggerEvent.create(
+        signal_id=SignalId("signal-001"),
+        instrument_id=InstrumentId("NSE:TEST"),
+        reference_price=Price(Decimal(reference)),
+        observed_price=Price(Decimal(observed)),
+        observed_at=datetime(2026, 8, 31, 10, 5, tzinfo=IST),
+        run=_run(),
+    )
+
+
+def test_paper_fill_uses_actual_observed_price() -> None:
+    trigger = _trigger(reference="100.10", observed="100.15")
+    result = PaperExecutionPort().execute(trigger, quantity=Quantity(10))
+
+    assert result.entry_intent.reference_price == Price(Decimal("100.10"))
+    assert result.fill.reference_price == Price(Decimal("100.10"))
+    assert result.fill.fill_price == Price(Decimal("100.15"))
+    assert result.fill.fill_price != result.fill.reference_price
+    assert result.fill.execution_mode is ExecutionMode.PAPER
+
+
+def test_gap_above_trigger_fills_at_observed_gap_price() -> None:
+    trigger = _trigger(reference="100.10", observed="101.25")
+    result = PaperExecutionPort().execute(trigger, quantity=Quantity(3))
+
+    assert result.fill.fill_price == Price(Decimal("101.25"))
+    assert result.fill.fill_price != Price(Decimal("100.10"))
+
+
+def test_quantity_is_supplied_by_caller_and_preserved() -> None:
+    result = PaperExecutionPort().execute(_trigger(), quantity=Quantity(17))
+
+    assert result.entry_intent.quantity == Quantity(17)
+    assert result.fill.quantity == Quantity(17)
+
+
+def test_trigger_evidence_timestamp_drives_intent_and_fill() -> None:
+    trigger = _trigger(observed="100.20")
+    result = PaperExecutionPort().execute(trigger, quantity=Quantity(2))
+
+    assert result.entry_intent.created_at == trigger.observed_at
+    assert result.fill.filled_at == trigger.observed_at
+
+
+def test_duplicate_execution_request_is_idempotent() -> None:
+    trigger = _trigger(observed="100.20")
+    port = PaperExecutionPort()
+
+    first = port.execute(trigger, quantity=Quantity(5))
+    second = port.execute(trigger, quantity=Quantity(5))
+
+    assert second is first
+    assert second.entry_intent.entry_intent_id == first.entry_intent.entry_intent_id
+    assert second.fill.fill_id == first.fill.fill_id
+
+
+def test_same_trigger_with_different_quantity_is_a_distinct_intent() -> None:
+    trigger = _trigger(observed="100.20")
+    port = PaperExecutionPort()
+
+    first = port.execute(trigger, quantity=Quantity(5))
+    second = port.execute(trigger, quantity=Quantity(6))
+
+    assert first.entry_intent.entry_intent_id != second.entry_intent.entry_intent_id
+    assert first.fill.fill_id != second.fill.fill_id
+
+
+def test_execution_is_deterministic_for_identical_inputs() -> None:
+    trigger = _trigger(reference="100.10", observed="100.35")
+
+    first = PaperExecutionPort().execute(trigger, quantity=Quantity(4))
+    second = PaperExecutionPort().execute(trigger, quantity=Quantity(4))
+
+    assert first == second


### PR DESCRIPTION
## What changed
Implements SF-034, the broker-independent PAPER execution boundary.

- Adds `PaperExecutionPort` and immutable `PaperExecutionResult`
- Builds EntryIntent and Fill from accepted TriggerEvent evidence
- Retains tradable trigger/reference price separately from actual fill price
- Uses the trigger event's actual observed eligible price as the paper fill price
- Gap-through entries fill at the observed gap price, never a fabricated trigger price
- Preserves caller-supplied quantity; no position sizing is introduced
- Uses PAPER execution mode only; no broker SDK/live order logic
- Duplicate logical requests return the same immutable intent/fill facts
- Tests actual observed-price fills, gaps, quantity, timestamp provenance, idempotency, distinct quantities, and determinism

## Scope boundary
No Trade/Position economics, target/stop computation, exits, broker adapters, or slippage model.

Closes #65 when merged.