### PR TITLE
SF-035 — Open Trade and Position from entry fill

### DIFF
--- a/signalforge/runtime/position_manager.py
+++ b/signalforge/runtime/position_manager.py
@@ -1,0 +1,100 @@
+"""Entry-fill to OPEN Trade/Position transition for the MVP lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from signalforge.domain.execution import Fill
+from signalforge.domain.ids import FillId
+from signalforge.domain.instruments import TickSizeSchedule
+from signalforge.domain.positions import Position
+from signalforge.domain.signals import Signal
+from signalforge.domain.time import IST
+from signalforge.domain.trades import Trade
+
+
+class PositionOpenRejection(StrEnum):
+    """Deterministic reasons an accepted Fill cannot open a position."""
+
+    NON_POSITIVE_RISK = "non_positive_risk"
+
+
+@dataclass(frozen=True, slots=True)
+class PositionOpenResult:
+    """Immutable result of processing one logical entry Fill."""
+
+    trade: Trade | None
+    position: Position | None
+    rejection: PositionOpenRejection | None = None
+
+    def __post_init__(self) -> None:
+        opened = self.trade is not None or self.position is not None
+        if opened:
+            if self.trade is None or self.position is None:
+                raise ValueError("Opened result requires both Trade and Position")
+            if self.rejection is not None:
+                raise ValueError("Opened result cannot include a rejection")
+            if self.position.trade_id != self.trade.trade_id:
+                raise ValueError("Position must belong to the produced Trade")
+        elif self.rejection is None:
+            raise ValueError("Rejected result requires an explicit rejection reason")
+
+    @property
+    def opened(self) -> bool:
+        return self.trade is not None
+
+
+class PositionManager:
+    """Open one Trade/Position pair from accepted entry-fill evidence."""
+
+    def __init__(self, *, tick_schedule: TickSizeSchedule) -> None:
+        self.tick_schedule = tick_schedule
+        self._results: dict[FillId, PositionOpenResult] = {}
+        self._signals: dict[FillId, str] = {}
+
+    def open_from_fill(self, fill: Fill, signal: Signal) -> PositionOpenResult:
+        """Process one Fill idempotently using the signal-candle low as stop."""
+
+        self._validate_contract(fill, signal)
+        prior = self._results.get(fill.fill_id)
+        if prior is not None:
+            if self._signals[fill.fill_id] != str(signal.signal_id):
+                raise ValueError("Fill was already processed against a different Signal")
+            return prior
+
+        risk_value = fill.fill_price.value - signal.signal_low.value
+        if risk_value <= 0:
+            result = PositionOpenResult(
+                trade=None,
+                position=None,
+                rejection=PositionOpenRejection.NON_POSITIVE_RISK,
+            )
+            self._remember(fill, signal, result)
+            return result
+
+        trading_date = fill.filled_at.astimezone(IST).date()
+        tick_size = self.tick_schedule.tick_size_on(trading_date)
+        trade = Trade.open_from_fill(
+            entry_fill=fill,
+            stop_price=signal.signal_low,
+            target_tick_size=tick_size,
+        )
+        position = Position.open_from_trade(trade=trade)
+        result = PositionOpenResult(trade=trade, position=position)
+        self._remember(fill, signal, result)
+        return result
+
+    def _validate_contract(self, fill: Fill, signal: Signal) -> None:
+        if fill.signal_id != signal.signal_id:
+            raise ValueError("Fill and Signal identities must match")
+        if fill.instrument_id != signal.instrument_id:
+            raise ValueError("Fill and Signal instruments must match")
+        if fill.run != signal.run:
+            raise ValueError("Fill and Signal run provenance must match")
+        if self.tick_schedule.instrument_id != fill.instrument_id:
+            raise ValueError("TickSizeSchedule instrument must match the Fill")
+
+    def _remember(self, fill: Fill, signal: Signal, result: PositionOpenResult) -> None:
+        self._results[fill.fill_id] = result
+        self._signals[fill.fill_id] = str(signal.signal_id)

--- a/tests/unit/runtime/test_position_manager.py
+++ b/tests/unit/runtime/test_position_manager.py
@@ -93,8 +93,8 @@ def test_target_rounds_up_using_effective_tick_schedule() -> None:
 
 
 def test_non_positive_risk_is_explicitly_rejected_without_open_lifecycle() -> None:
-    signal = _signal(low="101.10")
-    fill = _fill(signal, price="101.10")
+    signal = _signal(low="101.00")
+    fill = _fill(signal, price="101.00")
     result = PositionManager(tick_schedule=_schedule()).open_from_fill(fill, signal)
 
     assert result.opened is False

--- a/tests/unit/runtime/test_position_manager.py
+++ b/tests/unit/runtime/test_position_manager.py
@@ -1,0 +1,157 @@
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+from signalforge.domain.execution import ExecutionMode, Fill
+from signalforge.domain.ids import (
+    ConfigId,
+    EntryIntentId,
+    InstrumentId,
+    RunId,
+    SignalId,
+    TriggerEventId,
+)
+from signalforge.domain.instruments import TickSizeRule, TickSizeSchedule
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.time import IST, CandleInterval
+from signalforge.runtime.position_manager import PositionManager, PositionOpenRejection
+
+INSTRUMENT = InstrumentId("NSE:TEST")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-035"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-035"),
+        config_hash="hash-035",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _signal(*, low: str = "100.00") -> Signal:
+    end = datetime(2026, 8, 31, 10, 0, tzinfo=IST)
+    return Signal.create(
+        instrument_id=INSTRUMENT,
+        interval=CandleInterval(start=end - timedelta(minutes=5), end=end),
+        signal_close=Price(Decimal("101.00")),
+        signal_low=Price(Decimal(low)),
+        run=_run(),
+        created_at=end,
+    )
+
+
+def _fill(signal: Signal, *, price: str = "101.10", quantity: int = 10) -> Fill:
+    return Fill.create(
+        entry_intent_id=EntryIntentId("intent-035"),
+        trigger_event_id=TriggerEventId("trigger-035"),
+        signal_id=signal.signal_id,
+        instrument_id=signal.instrument_id,
+        reference_price=Price(Decimal("101.05")),
+        fill_price=Price(Decimal(price)),
+        quantity=Quantity(quantity),
+        execution_mode=ExecutionMode.PAPER,
+        filled_at=datetime(2026, 8, 31, 10, 1, tzinfo=IST),
+        run=signal.run,
+    )
+
+
+def _schedule(*, tick: str = "0.05") -> TickSizeSchedule:
+    return TickSizeSchedule(
+        instrument_id=INSTRUMENT,
+        rules=(
+            TickSizeRule(
+                tick_size=Price(Decimal(tick)),
+                effective_from=date(2026, 1, 1),
+            ),
+        ),
+    )
+
+
+def test_actual_fill_drives_risk_and_target_and_opens_one_to_one_position() -> None:
+    signal = _signal(low="100.00")
+    fill = _fill(signal, price="101.10", quantity=7)
+    result = PositionManager(tick_schedule=_schedule()).open_from_fill(fill, signal)
+
+    assert result.opened is True
+    assert result.rejection is None
+    assert result.trade is not None
+    assert result.position is not None
+    assert result.trade.entry_price == Price(Decimal("101.10"))
+    assert result.trade.stop_price == Price(Decimal("100.00"))
+    assert result.trade.risk_per_share == Price(Decimal("1.10"))
+    assert result.trade.raw_target_price == Price(Decimal("102.750"))
+    assert result.trade.tradable_target_price == Price(Decimal("102.75"))
+    assert result.trade.quantity == Quantity(7)
+    assert result.position.trade_id == result.trade.trade_id
+    assert result.position.average_entry_price == fill.fill_price
+    assert result.position.quantity == fill.quantity
+
+
+def test_target_rounds_up_using_effective_tick_schedule() -> None:
+    signal = _signal(low="100.00")
+    fill = _fill(signal, price="101.11")
+    result = PositionManager(tick_schedule=_schedule(tick="0.05")).open_from_fill(fill, signal)
+
+    assert result.trade is not None
+    assert result.trade.raw_target_price == Price(Decimal("102.775"))
+    assert result.trade.tradable_target_price == Price(Decimal("102.80"))
+
+
+def test_non_positive_risk_is_explicitly_rejected_without_open_lifecycle() -> None:
+    signal = _signal(low="101.10")
+    fill = _fill(signal, price="101.10")
+    result = PositionManager(tick_schedule=_schedule()).open_from_fill(fill, signal)
+
+    assert result.opened is False
+    assert result.trade is None
+    assert result.position is None
+    assert result.rejection is PositionOpenRejection.NON_POSITIVE_RISK
+
+
+def test_duplicate_fill_processing_is_idempotent() -> None:
+    signal = _signal()
+    fill = _fill(signal)
+    manager = PositionManager(tick_schedule=_schedule())
+
+    first = manager.open_from_fill(fill, signal)
+    second = manager.open_from_fill(fill, signal)
+
+    assert second is first
+    assert second.trade is first.trade
+    assert second.position is first.position
+
+
+def test_reference_trigger_price_does_not_drive_trade_economics() -> None:
+    signal = _signal(low="100.00")
+    fill = _fill(signal, price="101.40")
+    result = PositionManager(tick_schedule=_schedule()).open_from_fill(fill, signal)
+
+    assert fill.reference_price == Price(Decimal("101.05"))
+    assert result.trade is not None
+    assert result.trade.entry_price == Price(Decimal("101.40"))
+    assert result.trade.risk_per_share == Price(Decimal("1.40"))
+    assert result.trade.raw_target_price == Price(Decimal("103.500"))
+
+
+def test_fill_and_signal_identity_mismatch_fails_fast() -> None:
+    signal = _signal()
+    fill = _fill(signal)
+    other_signal = Signal(
+        signal_id=SignalId("other"),
+        instrument_id=signal.instrument_id,
+        interval=signal.interval,
+        signal_close=signal.signal_close,
+        signal_low=signal.signal_low,
+        run=signal.run,
+        created_at=signal.created_at,
+    )
+
+    manager = PositionManager(tick_schedule=_schedule())
+    try:
+        manager.open_from_fill(fill, other_signal)
+    except ValueError as exc:
+        assert "identities must match" in str(exc)
+    else:
+        raise AssertionError("expected identity mismatch to fail")

--- a/tests/unit/runtime/test_position_manager.py
+++ b/tests/unit/runtime/test_position_manager.py
@@ -2,14 +2,7 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 
 from signalforge.domain.execution import ExecutionMode, Fill
-from signalforge.domain.ids import (
-    ConfigId,
-    EntryIntentId,
-    InstrumentId,
-    RunId,
-    SignalId,
-    TriggerEventId,
-)
+from signalforge.domain.ids import ConfigId, EntryIntentId, InstrumentId, RunId, TriggerEventId
 from signalforge.domain.instruments import TickSizeRule, TickSizeSchedule
 from signalforge.domain.money import Price, Quantity
 from signalforge.domain.provenance import RunIdentity, StrategyIdentity
@@ -30,8 +23,8 @@ def _run() -> RunIdentity:
     )
 
 
-def _signal(*, low: str = "100.00") -> Signal:
-    end = datetime(2026, 8, 31, 10, 0, tzinfo=IST)
+def _signal(*, low: str = "100.00", end_minute: int = 0) -> Signal:
+    end = datetime(2026, 8, 31, 10, end_minute, tzinfo=IST)
     return Signal.create(
         instrument_id=INSTRUMENT,
         interval=CandleInterval(start=end - timedelta(minutes=5), end=end),
@@ -138,15 +131,7 @@ def test_reference_trigger_price_does_not_drive_trade_economics() -> None:
 def test_fill_and_signal_identity_mismatch_fails_fast() -> None:
     signal = _signal()
     fill = _fill(signal)
-    other_signal = Signal(
-        signal_id=SignalId("other"),
-        instrument_id=signal.instrument_id,
-        interval=signal.interval,
-        signal_close=signal.signal_close,
-        signal_low=signal.signal_low,
-        run=signal.run,
-        created_at=signal.created_at,
-    )
+    other_signal = _signal(end_minute=5)
 
     manager = PositionManager(tick_schedule=_schedule())
     try:


### PR DESCRIPTION
## What changed
Implements SF-035, the entry-fill to OPEN Trade/Position transition.

- Adds `PositionManager`, `PositionOpenResult`, and explicit `NON_POSITIVE_RISK` rejection
- Validates Fill↔Signal identity, instrument, and run provenance
- Uses signal-candle low as the stop anchor
- Calculates risk and 1.5R target from the actual Fill price via existing domain constructors
- Resolves effective-dated tick size from `TickSizeSchedule` and rounds executable target upward
- Creates exactly one OPEN Trade and one OPEN Position for a successful fill
- Preserves caller-supplied quantity; no position-sizing strategy is introduced
- Duplicate logical Fill processing is idempotent
- Tests actual-fill economics, target rounding, non-positive-risk rejection, idempotency, reference-price independence, and contract mismatch handling

## Scope boundary
No exit evaluation, broker logic, persistence, or position-sizing strategy.

Closes #66 when merged.