### PR TITLE
SF-036 — Add deterministic OPEN position exit evaluation

### DIFF
--- a/signalforge/runtime/position_manager.py
+++ b/signalforge/runtime/position_manager.py
@@ -1,17 +1,22 @@
-"""Entry-fill to OPEN Trade/Position transition for the MVP lifecycle."""
+"""Entry and exit management for the MVP Trade/Position lifecycle."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, time
 from enum import StrEnum
 
-from signalforge.domain.execution import Fill
-from signalforge.domain.ids import FillId
+from signalforge.domain.execution import ExecutionMode, Fill
+from signalforge.domain.exits import Exit, ExitReason
+from signalforge.domain.ids import FillId, TradeId, deterministic_id
 from signalforge.domain.instruments import TickSizeSchedule
-from signalforge.domain.positions import Position
+from signalforge.domain.market import MarketEvent
+from signalforge.domain.positions import Position, PositionState
 from signalforge.domain.signals import Signal
 from signalforge.domain.time import IST
-from signalforge.domain.trades import Trade
+from signalforge.domain.trades import Trade, TradeState
+
+_FORCED_EXIT_TIME = time(15, 15)
 
 
 class PositionOpenRejection(StrEnum):
@@ -46,12 +51,13 @@ class PositionOpenResult:
 
 
 class PositionManager:
-    """Open one Trade/Position pair from accepted entry-fill evidence."""
+    """Own deterministic OPEN and CLOSED Trade/Position transitions."""
 
     def __init__(self, *, tick_schedule: TickSizeSchedule) -> None:
         self.tick_schedule = tick_schedule
         self._results: dict[FillId, PositionOpenResult] = {}
         self._signals: dict[FillId, str] = {}
+        self._exits: dict[TradeId, Exit] = {}
 
     def open_from_fill(self, fill: Fill, signal: Signal) -> PositionOpenResult:
         """Process one Fill idempotently using the signal-candle low as stop."""
@@ -85,6 +91,70 @@ class PositionManager:
         self._remember(fill, signal, result)
         return result
 
+    def process_market_event(
+        self,
+        trade: Trade,
+        position: Position,
+        event: MarketEvent,
+        *,
+        execution_mode: ExecutionMode = ExecutionMode.PAPER,
+    ) -> Exit | None:
+        """Close an OPEN long position on the first qualifying ordered market event."""
+
+        prior = self._exits.get(trade.trade_id)
+        if prior is not None:
+            return prior
+
+        self._validate_exit_contract(trade, position, event)
+        reason_reference = self._exit_reason_and_reference(trade, event)
+        if reason_reference is None:
+            return None
+        reason, reference_price = reason_reference
+
+        exit_fill_id = deterministic_id(
+            FillId,
+            str(trade.run.run_id),
+            str(trade.trade_id),
+            "exit",
+            event.exchange_timestamp.isoformat(),
+            str(event.price.value),
+            reason.value,
+        )
+        exit_fact = Exit.create(
+            trade=trade,
+            position=position,
+            exit_fill_id=exit_fill_id,
+            reason=reason,
+            reference_price=reference_price,
+            fill_price=event.price,
+            quantity=trade.quantity,
+            execution_mode=execution_mode,
+            exited_at=event.exchange_timestamp,
+        )
+        trade.close(exit_id=exit_fact.exit_id, at=exit_fact.exited_at)
+        position.close(at=exit_fact.exited_at)
+        self._exits[trade.trade_id] = exit_fact
+        return exit_fact
+
+    def _exit_reason_and_reference(
+        self,
+        trade: Trade,
+        event: MarketEvent,
+    ) -> tuple[ExitReason, object] | None:
+        forced_at = self._forced_exit_at(event.exchange_timestamp)
+        if event.exchange_timestamp >= forced_at:
+            return ExitReason.FORCED_SESSION_EXIT, event.price
+        if event.price.value <= trade.stop_price.value:
+            return ExitReason.STOP, trade.stop_price
+        if event.price.value >= trade.tradable_target_price.value:
+            return ExitReason.TARGET, trade.tradable_target_price
+        return None
+
+    @staticmethod
+    def _forced_exit_at(at: datetime) -> datetime:
+        local = at.astimezone(IST)
+        return datetime.combine(local.date(), _FORCED_EXIT_TIME, tzinfo=IST)
+
     def _validate_contract(self, fill: Fill, signal: Signal) -> None:
         if fill.signal_id != signal.signal_id:
             raise ValueError("Fill and Signal identities must match")
@@ -94,6 +164,23 @@ class PositionManager:
             raise ValueError("Fill and Signal run provenance must match")
         if self.tick_schedule.instrument_id != fill.instrument_id:
             raise ValueError("TickSizeSchedule instrument must match the Fill")
+
+    def _validate_exit_contract(
+        self,
+        trade: Trade,
+        position: Position,
+        event: MarketEvent,
+    ) -> None:
+        if trade.state is not TradeState.OPEN or position.state is not PositionState.OPEN:
+            raise ValueError("Exit evaluation requires OPEN Trade and Position")
+        if position.trade_id != trade.trade_id:
+            raise ValueError("Position must belong to the Trade being evaluated")
+        if position.instrument_id != trade.instrument_id or event.instrument_id != trade.instrument_id:
+            raise ValueError("Trade, Position, and MarketEvent instruments must match")
+        if position.run != trade.run:
+            raise ValueError("Trade and Position run provenance must match")
+        if event.exchange_timestamp < trade.opened_at:
+            raise ValueError("Exit market event must not precede Trade open timestamp")
 
     def _remember(self, fill: Fill, signal: Signal, result: PositionOpenResult) -> None:
         self._results[fill.fill_id] = result

--- a/signalforge/runtime/position_manager.py
+++ b/signalforge/runtime/position_manager.py
@@ -176,7 +176,11 @@ class PositionManager:
             raise ValueError("Exit evaluation requires OPEN Trade and Position")
         if position.trade_id != trade.trade_id:
             raise ValueError("Position must belong to the Trade being evaluated")
-        if position.instrument_id != trade.instrument_id or event.instrument_id != trade.instrument_id:
+        instruments_mismatch = (
+            position.instrument_id != trade.instrument_id
+            or event.instrument_id != trade.instrument_id
+        )
+        if instruments_mismatch:
             raise ValueError("Trade, Position, and MarketEvent instruments must match")
         if position.run != trade.run:
             raise ValueError("Trade and Position run provenance must match")

--- a/signalforge/runtime/position_manager.py
+++ b/signalforge/runtime/position_manager.py
@@ -11,6 +11,7 @@ from signalforge.domain.exits import Exit, ExitReason
 from signalforge.domain.ids import FillId, TradeId, deterministic_id
 from signalforge.domain.instruments import TickSizeSchedule
 from signalforge.domain.market import MarketEvent
+from signalforge.domain.money import Price
 from signalforge.domain.positions import Position, PositionState
 from signalforge.domain.signals import Signal
 from signalforge.domain.time import IST
@@ -140,7 +141,7 @@ class PositionManager:
         self,
         trade: Trade,
         event: MarketEvent,
-    ) -> tuple[ExitReason, object] | None:
+    ) -> tuple[ExitReason, Price] | None:
         forced_at = self._forced_exit_at(event.exchange_timestamp)
         if event.exchange_timestamp >= forced_at:
             return ExitReason.FORCED_SESSION_EXIT, event.price

--- a/tests/unit/runtime/test_position_exit.py
+++ b/tests/unit/runtime/test_position_exit.py
@@ -7,11 +7,11 @@ from signalforge.domain.ids import ConfigId, EntryIntentId, InstrumentId, RunId,
 from signalforge.domain.instruments import TickSizeRule, TickSizeSchedule
 from signalforge.domain.market import MarketEvent
 from signalforge.domain.money import Price, Quantity
-from signalforge.domain.positions import PositionState
+from signalforge.domain.positions import Position, PositionState
 from signalforge.domain.provenance import RunIdentity, StrategyIdentity
 from signalforge.domain.signals import Signal
 from signalforge.domain.time import IST, CandleInterval
-from signalforge.domain.trades import TradeState
+from signalforge.domain.trades import Trade, TradeState
 from signalforge.runtime.position_manager import PositionManager
 
 INSTRUMENT = InstrumentId("NSE:TEST")
@@ -34,7 +34,7 @@ def _schedule() -> TickSizeSchedule:
     )
 
 
-def _open_position() -> tuple[PositionManager, object, object]:
+def _open_position() -> tuple[PositionManager, Trade, Position]:
     end = datetime(2026, 8, 31, 10, 0, tzinfo=IST)
     signal = Signal.create(
         instrument_id=INSTRUMENT,

--- a/tests/unit/runtime/test_position_exit.py
+++ b/tests/unit/runtime/test_position_exit.py
@@ -1,0 +1,165 @@
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+from signalforge.domain.execution import ExecutionMode, Fill
+from signalforge.domain.exits import ExitReason
+from signalforge.domain.ids import ConfigId, EntryIntentId, InstrumentId, RunId, TriggerEventId
+from signalforge.domain.instruments import TickSizeRule, TickSizeSchedule
+from signalforge.domain.market import MarketEvent
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.positions import PositionState
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.time import IST, CandleInterval
+from signalforge.domain.trades import TradeState
+from signalforge.runtime.position_manager import PositionManager
+
+INSTRUMENT = InstrumentId("NSE:TEST")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-036"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-036"),
+        config_hash="hash-036",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _schedule() -> TickSizeSchedule:
+    return TickSizeSchedule(
+        instrument_id=INSTRUMENT,
+        rules=(TickSizeRule(Price(Decimal("0.05")), date(2026, 1, 1)),),
+    )
+
+
+def _open_position() -> tuple[PositionManager, object, object]:
+    end = datetime(2026, 8, 31, 10, 0, tzinfo=IST)
+    signal = Signal.create(
+        instrument_id=INSTRUMENT,
+        interval=CandleInterval(start=end - timedelta(minutes=5), end=end),
+        signal_close=Price(Decimal("101.00")),
+        signal_low=Price(Decimal("100.00")),
+        run=_run(),
+        created_at=end,
+    )
+    fill = Fill.create(
+        entry_intent_id=EntryIntentId("intent-036"),
+        trigger_event_id=TriggerEventId("trigger-036"),
+        signal_id=signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=Price(Decimal("101.05")),
+        fill_price=Price(Decimal("101.10")),
+        quantity=Quantity(10),
+        execution_mode=ExecutionMode.PAPER,
+        filled_at=datetime(2026, 8, 31, 10, 1, tzinfo=IST),
+        run=_run(),
+    )
+    manager = PositionManager(tick_schedule=_schedule())
+    opened = manager.open_from_fill(fill, signal)
+    assert opened.trade is not None and opened.position is not None
+    return manager, opened.trade, opened.position
+
+
+def _event(price: str, *, hour: int = 10, minute: int = 5) -> MarketEvent:
+    at = datetime(2026, 8, 31, hour, minute, tzinfo=IST)
+    return MarketEvent(
+        instrument_id=INSTRUMENT,
+        exchange_timestamp=at,
+        received_timestamp=at,
+        price=Price(Decimal(price)),
+        quantity=1,
+        source="test",
+    )
+
+
+def test_stop_equality_closes_at_actual_observed_price() -> None:
+    manager, trade, position = _open_position()
+    exit_fact = manager.process_market_event(trade, position, _event("100.00"))
+
+    assert exit_fact is not None
+    assert exit_fact.reason is ExitReason.STOP
+    assert exit_fact.reference_price == Price(Decimal("100.00"))
+    assert exit_fact.fill_price == Price(Decimal("100.00"))
+    assert trade.state is TradeState.CLOSED
+    assert position.state is PositionState.CLOSED
+
+
+def test_stop_gap_through_uses_observed_price_and_actual_realised_values() -> None:
+    manager, trade, position = _open_position()
+    exit_fact = manager.process_market_event(trade, position, _event("99.50"))
+
+    assert exit_fact is not None
+    assert exit_fact.reason is ExitReason.STOP
+    assert exit_fact.reference_price == Price(Decimal("100.00"))
+    assert exit_fact.fill_price == Price(Decimal("99.50"))
+    assert exit_fact.realised_pnl == Decimal("-16.00")
+    assert exit_fact.realised_r == Decimal("-1.454545454545454545454545455")
+
+
+def test_target_equality_and_gap_through_use_actual_observed_price() -> None:
+    manager, trade, position = _open_position()
+    target = trade.tradable_target_price
+    at_target = manager.process_market_event(trade, position, _event(str(target.value)))
+
+    assert at_target is not None
+    assert at_target.reason is ExitReason.TARGET
+    assert at_target.fill_price == target
+
+    manager2, trade2, position2 = _open_position()
+    gap = manager2.process_market_event(trade2, position2, _event("103.20"))
+    assert gap is not None
+    assert gap.reason is ExitReason.TARGET
+    assert gap.reference_price == trade2.tradable_target_price
+    assert gap.fill_price == Price(Decimal("103.20"))
+
+
+def test_non_crossing_event_keeps_position_open() -> None:
+    manager, trade, position = _open_position()
+
+    assert manager.process_market_event(trade, position, _event("101.50")) is None
+    assert trade.state is TradeState.OPEN
+    assert position.state is PositionState.OPEN
+
+
+def test_first_valid_event_at_1515_forces_exit_even_if_price_is_beyond_target() -> None:
+    manager, trade, position = _open_position()
+    exit_fact = manager.process_market_event(trade, position, _event("104.00", hour=15, minute=15))
+
+    assert exit_fact is not None
+    assert exit_fact.reason is ExitReason.FORCED_SESSION_EXIT
+    assert exit_fact.reference_price == Price(Decimal("104.00"))
+    assert exit_fact.fill_price == Price(Decimal("104.00"))
+
+
+def test_pre_1515_cross_uses_stop_or_target_not_forced_exit() -> None:
+    manager, trade, position = _open_position()
+    exit_fact = manager.process_market_event(trade, position, _event("103.00", hour=15, minute=14))
+
+    assert exit_fact is not None
+    assert exit_fact.reason is ExitReason.TARGET
+
+
+def test_duplicate_event_processing_returns_same_exit_without_double_close() -> None:
+    manager, trade, position = _open_position()
+    event = _event("99.80")
+
+    first = manager.process_market_event(trade, position, event)
+    second = manager.process_market_event(trade, position, event)
+
+    assert first is not None
+    assert second is first
+    assert trade.state is TradeState.CLOSED
+    assert position.state is PositionState.CLOSED
+
+
+def test_later_event_after_terminal_exit_cannot_replace_first_exit() -> None:
+    manager, trade, position = _open_position()
+    first = manager.process_market_event(trade, position, _event("99.90"))
+    later = manager.process_market_event(trade, position, _event("104.00", minute=6))
+
+    assert later is first
+    assert first is not None
+    assert first.reason is ExitReason.STOP
+    assert first.fill_price == Price(Decimal("99.90"))


### PR DESCRIPTION
## What changed
Implements SF-036 deterministic exit evaluation for OPEN Trade/Position state.

- Evaluates ordered observed MarketEvent evidence only
- STOP when observed price <= persisted stop
- TARGET when observed price >= executable target
- Equality counts as crossing
- Gap-through exits use actual observed price, not theoretical stop/target
- First valid event at or after 15:15 IST uses FORCED_SESSION_EXIT
- Reuses existing Exit domain fact for realised P&L/R from actual entry/exit prices
- Closes Trade and Position on the same accepted exit fact
- Duplicate/later event processing is idempotent and cannot replace the first terminal Exit
- No OHLC favorable ordering, broker logic, persistence, or replay framework added

Closes #67 when merged.