### PR TITLE
SF-037 — Add deterministic M4 lifecycle coordinator

### DIFF
--- a/signalforge/runtime/lifecycle.py
+++ b/signalforge/runtime/lifecycle.py
@@ -109,6 +109,10 @@ class LifecycleCoordinator:
             open_position=self.state is LifecycleState.OPEN,
         )
         if arming is not None:
+            if before is not arming:
+                self._execution = None
+                self._open_result = None
+                self._exit = None
             self._arming = arming
             if before is not arming:
                 self._record(

--- a/signalforge/runtime/lifecycle.py
+++ b/signalforge/runtime/lifecycle.py
@@ -1,0 +1,296 @@
+"""Thin deterministic coordinator for the in-memory M4 paper lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from signalforge.domain.armed import ArmedSetupState
+from signalforge.domain.audit import StateTransition, TransitionEntityType
+from signalforge.domain.exits import Exit
+from signalforge.domain.instruments import TickSizeSchedule
+from signalforge.domain.market import CompletedCandle, MarketEvent
+from signalforge.domain.money import Quantity
+from signalforge.domain.positions import Position, PositionState
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.time import require_aware
+from signalforge.domain.trades import Trade, TradeState
+from signalforge.runtime.execution import PaperExecutionPort, PaperExecutionResult
+from signalforge.runtime.position_manager import PositionManager, PositionOpenResult
+from signalforge.runtime.signal_lifecycle import SignalArmingResult, SignalLifecycleManager
+from signalforge.runtime.strategy_evaluator import StrategyEvaluatorResult
+
+
+class LifecycleState(StrEnum):
+    IDLE = "idle"
+    ARMED = "armed"
+    TRIGGERED = "triggered"
+    EXPIRED = "expired"
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleSnapshot:
+    state: LifecycleState
+    arming: SignalArmingResult | None
+    execution: PaperExecutionResult | None
+    open_result: PositionOpenResult | None
+    exit: Exit | None
+
+
+class LifecycleCoordinator:
+    """Serially compose M4 components without duplicating their business rules."""
+
+    def __init__(
+        self,
+        *,
+        run: RunIdentity,
+        tick_schedule: TickSizeSchedule,
+        quantity: Quantity,
+    ) -> None:
+        self.run = run
+        self.quantity = quantity
+        self.signal_lifecycle = SignalLifecycleManager(run=run, tick_schedule=tick_schedule)
+        self.execution_port = PaperExecutionPort()
+        self.position_manager = PositionManager(tick_schedule=tick_schedule)
+        self._arming: SignalArmingResult | None = None
+        self._execution: PaperExecutionResult | None = None
+        self._open_result: PositionOpenResult | None = None
+        self._exit: Exit | None = None
+        self._audit: dict[str, StateTransition] = {}
+
+    @property
+    def audit_transitions(self) -> tuple[StateTransition, ...]:
+        return tuple(self._audit.values())
+
+    @property
+    def state(self) -> LifecycleState:
+        if self._exit is not None:
+            return LifecycleState.CLOSED
+        if self._open_result is not None and self._open_result.opened:
+            trade = self._open_result.trade
+            position = self._open_result.position
+            if trade is None or position is None:
+                raise RuntimeError("Opened lifecycle is missing Trade or Position")
+            if trade.state is TradeState.CLOSED or position.state is PositionState.CLOSED:
+                raise RuntimeError("Closed Trade/Position requires an Exit fact")
+            return LifecycleState.OPEN
+        if self._arming is None:
+            return LifecycleState.IDLE
+        setup_state = self._arming.armed_setup.state
+        if setup_state is ArmedSetupState.ARMED:
+            return LifecycleState.ARMED
+        if setup_state is ArmedSetupState.TRIGGERED:
+            return LifecycleState.TRIGGERED
+        return LifecycleState.EXPIRED
+
+    def snapshot(self) -> LifecycleSnapshot:
+        return LifecycleSnapshot(
+            state=self.state,
+            arming=self._arming,
+            execution=self._execution,
+            open_result=self._open_result,
+            exit=self._exit,
+        )
+
+    def process_evaluation(
+        self,
+        candle: CompletedCandle,
+        evaluator_result: StrategyEvaluatorResult,
+    ) -> LifecycleSnapshot:
+        """Route one already-computed strategy evaluation into Signal/ARMED creation."""
+
+        before = self.signal_lifecycle.active
+        arming = self.signal_lifecycle.arm_if_actionable(
+            candle,
+            evaluator_result,
+            open_position=self.state is LifecycleState.OPEN,
+        )
+        if arming is not None:
+            self._arming = arming
+            if before is not arming:
+                self._record(
+                    entity_type=TransitionEntityType.ARMED_SETUP,
+                    entity_id=str(arming.signal.signal_id),
+                    from_state="none",
+                    to_state=ArmedSetupState.ARMED.value,
+                    cause_type="strategy_evaluation",
+                    cause_id=self._evaluation_cause_id(evaluator_result),
+                    occurred_at=arming.armed_setup.armed_at,
+                )
+        return self.snapshot()
+
+    def process_market_event(self, event: MarketEvent) -> LifecycleSnapshot:
+        """Route one ordered market event through ARMED or OPEN lifecycle handling."""
+
+        if self.state is LifecycleState.OPEN:
+            self._process_open_event(event)
+            return self.snapshot()
+
+        arming = self._arming
+        if arming is None or arming.armed_setup.state is not ArmedSetupState.ARMED:
+            return self.snapshot()
+
+        prior_state = arming.armed_setup.state
+        trigger = self.signal_lifecycle.process_market_event(event)
+        self._record_setup_terminal_if_changed(arming, prior_state, event)
+        if trigger is None:
+            return self.snapshot()
+
+        self._execution = self.execution_port.execute(trigger, quantity=self.quantity)
+        self._open_result = self.position_manager.open_from_fill(
+            self._execution.fill,
+            arming.signal,
+        )
+        if self._open_result.opened:
+            trade = self._require_trade()
+            position = self._require_position()
+            self._record(
+                entity_type=TransitionEntityType.TRADE,
+                entity_id=str(trade.trade_id),
+                from_state="none",
+                to_state=TradeState.OPEN.value,
+                cause_type="fill",
+                cause_id=str(self._execution.fill.fill_id),
+                occurred_at=trade.opened_at,
+            )
+            self._record(
+                entity_type=TransitionEntityType.POSITION,
+                entity_id=str(position.position_id),
+                from_state="none",
+                to_state=PositionState.OPEN.value,
+                cause_type="trade",
+                cause_id=str(trade.trade_id),
+                occurred_at=position.opened_at,
+            )
+        return self.snapshot()
+
+    def process_completed_candle(self, candle: CompletedCandle) -> LifecycleSnapshot:
+        arming = self._arming
+        if arming is None or arming.armed_setup.state is not ArmedSetupState.ARMED:
+            return self.snapshot()
+        prior_state = arming.armed_setup.state
+        self.signal_lifecycle.process_completed_candle(candle)
+        self._record_setup_terminal_if_changed(arming, prior_state, candle)
+        return self.snapshot()
+
+    def process_time(self, at: datetime) -> LifecycleSnapshot:
+        require_aware(at)
+        arming = self._arming
+        if arming is None or arming.armed_setup.state is not ArmedSetupState.ARMED:
+            return self.snapshot()
+        prior_state = arming.armed_setup.state
+        self.signal_lifecycle.process_time(at)
+        self._record_setup_terminal_if_changed(arming, prior_state, at)
+        return self.snapshot()
+
+    def _process_open_event(self, event: MarketEvent) -> None:
+        trade = self._require_trade()
+        position = self._require_position()
+        exit_fact = self.position_manager.process_market_event(trade, position, event)
+        if exit_fact is None:
+            return
+        prior_exit = self._exit
+        self._exit = exit_fact
+        if prior_exit is not None:
+            return
+        self._record(
+            entity_type=TransitionEntityType.TRADE,
+            entity_id=str(trade.trade_id),
+            from_state=TradeState.OPEN.value,
+            to_state=TradeState.CLOSED.value,
+            cause_type="exit",
+            cause_id=str(exit_fact.exit_id),
+            occurred_at=exit_fact.exited_at,
+        )
+        self._record(
+            entity_type=TransitionEntityType.POSITION,
+            entity_id=str(position.position_id),
+            from_state=PositionState.OPEN.value,
+            to_state=PositionState.CLOSED.value,
+            cause_type="exit",
+            cause_id=str(exit_fact.exit_id),
+            occurred_at=exit_fact.exited_at,
+        )
+
+    def _record_setup_terminal_if_changed(
+        self,
+        arming: SignalArmingResult,
+        prior_state: ArmedSetupState,
+        cause: object,
+    ) -> None:
+        setup = arming.armed_setup
+        if setup.state is prior_state:
+            return
+        if setup.terminal_at is None:
+            raise RuntimeError("Terminal ArmedSetup requires terminal_at")
+        if setup.state is ArmedSetupState.TRIGGERED:
+            trigger = self.signal_lifecycle.trigger_event
+            if trigger is None:
+                raise RuntimeError("TRIGGERED ArmedSetup requires TriggerEvent")
+            cause_type = "trigger_event"
+            cause_id = str(trigger.trigger_event_id)
+        else:
+            cause_type = type(cause).__name__
+            cause_id = self._cause_id(cause)
+        self._record(
+            entity_type=TransitionEntityType.ARMED_SETUP,
+            entity_id=str(arming.signal.signal_id),
+            from_state=prior_state.value,
+            to_state=setup.state.value,
+            cause_type=cause_type,
+            cause_id=cause_id,
+            occurred_at=setup.terminal_at,
+        )
+
+    def _record(
+        self,
+        *,
+        entity_type: TransitionEntityType,
+        entity_id: str,
+        from_state: str,
+        to_state: str,
+        cause_type: str,
+        cause_id: str,
+        occurred_at: datetime,
+    ) -> None:
+        fact = StateTransition.create(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            from_state=from_state,
+            to_state=to_state,
+            cause_type=cause_type,
+            cause_id=cause_id,
+            occurred_at=occurred_at,
+            run=self.run,
+        )
+        self._audit.setdefault(str(fact.transition_id), fact)
+
+    def _require_trade(self) -> Trade:
+        if self._open_result is None or self._open_result.trade is None:
+            raise RuntimeError("Lifecycle has no Trade")
+        return self._open_result.trade
+
+    def _require_position(self) -> Position:
+        if self._open_result is None or self._open_result.position is None:
+            raise RuntimeError("Lifecycle has no Position")
+        return self._open_result.position
+
+    @staticmethod
+    def _evaluation_cause_id(result: StrategyEvaluatorResult) -> str:
+        evaluation = result.evaluation
+        return f"{evaluation.instrument_id}:{evaluation.interval.start.isoformat()}"
+
+    @staticmethod
+    def _cause_id(cause: object) -> str:
+        if isinstance(cause, CompletedCandle):
+            return f"{cause.instrument_id}:{cause.interval.start.isoformat()}"
+        if isinstance(cause, MarketEvent):
+            return cause.source_event_id or (
+                f"{cause.instrument_id}:{cause.exchange_timestamp.isoformat()}:{cause.price.value}"
+            )
+        if isinstance(cause, datetime):
+            return cause.isoformat()
+        return type(cause).__name__

--- a/tests/integration/runtime/test_lifecycle_coordinator.py
+++ b/tests/integration/runtime/test_lifecycle_coordinator.py
@@ -163,7 +163,11 @@ def test_exit_closes_trade_and_position_once_and_duplicate_is_idempotent() -> No
     assert first.exit is not None
     assert second.exit is first.exit
     assert len(coordinator.audit_transitions) == audit_count
-    assert [(t.entity_type.value, t.from_state, t.to_state) for t in coordinator.audit_transitions[-2:]] == [
+    closing_transitions = [
+        (t.entity_type.value, t.from_state, t.to_state)
+        for t in coordinator.audit_transitions[-2:]
+    ]
+    assert closing_transitions == [
         ("trade", "open", "closed"),
         ("position", "open", "closed"),
     ]

--- a/tests/integration/runtime/test_lifecycle_coordinator.py
+++ b/tests/integration/runtime/test_lifecycle_coordinator.py
@@ -1,0 +1,208 @@
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.audit import TransitionEntityType
+from signalforge.domain.ids import ConfigId, InstrumentId, RunId
+from signalforge.domain.indicators import IndicatorSnapshot
+from signalforge.domain.instruments import TickSizeRule, TickSizeSchedule
+from signalforge.domain.market import CandleQuality, CompletedCandle, MarketEvent
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.time import IST, CandleInterval
+from signalforge.runtime.eligibility import MarketDataFeedState
+from signalforge.runtime.indicators import IndicatorContinuity
+from signalforge.runtime.lifecycle import LifecycleCoordinator, LifecycleState
+from signalforge.runtime.strategy_evaluator import (
+    StrategyEvaluationContext,
+    StrategyEvaluator,
+)
+
+INSTRUMENT = InstrumentId("NSE:RELIANCE")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-037"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-037"),
+        config_hash="hash-037",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _schedule() -> TickSizeSchedule:
+    return TickSizeSchedule(
+        instrument_id=INSTRUMENT,
+        rules=(TickSizeRule(Price(Decimal("0.10")), date(2026, 1, 1)),),
+    )
+
+
+def _candle(*, end_minute: int = 0) -> CompletedCandle:
+    end = datetime(2026, 8, 31, 10, end_minute, tzinfo=IST)
+    return CompletedCandle(
+        instrument_id=INSTRUMENT,
+        interval=CandleInterval(start=end - timedelta(minutes=5), end=end),
+        quality=CandleQuality.VALID,
+        open=Price(Decimal("100.00")),
+        high=Price(Decimal("102.00")),
+        low=Price(Decimal("99.00")),
+        close=Price(Decimal("100.11")),
+        volume=100,
+        source="test",
+        source_event_count=4,
+    )
+
+
+def _evaluation(candle: CompletedCandle):
+    snapshot = IndicatorSnapshot(
+        instrument_id=INSTRUMENT,
+        interval=candle.interval,
+        ready=True,
+        calculation_version="engine-v1",
+        ema9=Decimal("99"),
+        ema20=Decimal("101"),
+        ema50=Decimal("100"),
+        rsi14=Decimal("60"),
+        adx14=Decimal("23"),
+        macd_line=Decimal("1"),
+        macd_signal=Decimal("0.5"),
+        macd_histogram=Decimal("0.5"),
+    )
+    return StrategyEvaluator(StrategyV1EvaluationConfig()).evaluate(
+        candle,
+        snapshot,
+        StrategyEvaluationContext(
+            completed_regular_session_candles=250,
+            continuity=IndicatorContinuity.HEALTHY,
+            feed_state=MarketDataFeedState.HEALTHY,
+        ),
+    )
+
+
+def _event(price: str, minute: int, *, instrument: InstrumentId = INSTRUMENT) -> MarketEvent:
+    at = datetime(2026, 8, 31, 10, minute, tzinfo=IST)
+    return MarketEvent(
+        instrument_id=instrument,
+        exchange_timestamp=at,
+        received_timestamp=at,
+        price=Price(Decimal(price)),
+        quantity=1,
+        source="test",
+        source_event_id=f"evt-{minute}-{price}",
+    )
+
+
+def _coordinator() -> LifecycleCoordinator:
+    return LifecycleCoordinator(run=_run(), tick_schedule=_schedule(), quantity=Quantity(10))
+
+
+def test_actionable_evaluation_arms_and_duplicate_is_idempotent() -> None:
+    coordinator = _coordinator()
+    candle = _candle()
+    result = _evaluation(candle)
+
+    first = coordinator.process_evaluation(candle, result)
+    second = coordinator.process_evaluation(candle, result)
+
+    assert first.state is LifecycleState.ARMED
+    assert second.arming is first.arming
+    assert len(coordinator.audit_transitions) == 1
+    transition = coordinator.audit_transitions[0]
+    assert transition.entity_type is TransitionEntityType.ARMED_SETUP
+    assert (transition.from_state, transition.to_state) == ("none", "armed")
+
+
+def test_trigger_routes_through_paper_fill_to_open_and_audits_all_transitions() -> None:
+    coordinator = _coordinator()
+    candle = _candle()
+    coordinator.process_evaluation(candle, _evaluation(candle))
+
+    snapshot = coordinator.process_market_event(_event("100.30", 1))
+
+    assert snapshot.state is LifecycleState.OPEN
+    assert snapshot.execution is not None
+    assert snapshot.execution.fill.fill_price == Price(Decimal("100.30"))
+    assert snapshot.open_result is not None and snapshot.open_result.opened
+    transitions = coordinator.audit_transitions
+    assert [(t.entity_type.value, t.from_state, t.to_state) for t in transitions] == [
+        ("armed_setup", "none", "armed"),
+        ("armed_setup", "armed", "triggered"),
+        ("trade", "none", "open"),
+        ("position", "none", "open"),
+    ]
+
+
+def test_open_position_blocks_later_actionable_evaluation_from_pyramiding() -> None:
+    coordinator = _coordinator()
+    first_candle = _candle()
+    coordinator.process_evaluation(first_candle, _evaluation(first_candle))
+    coordinator.process_market_event(_event("100.30", 1))
+
+    later = _candle(end_minute=5)
+    snapshot = coordinator.process_evaluation(later, _evaluation(later))
+
+    assert snapshot.state is LifecycleState.OPEN
+    assert snapshot.arming is not None
+    assert snapshot.arming.signal.interval == first_candle.interval
+
+
+def test_exit_closes_trade_and_position_once_and_duplicate_is_idempotent() -> None:
+    coordinator = _coordinator()
+    candle = _candle()
+    coordinator.process_evaluation(candle, _evaluation(candle))
+    coordinator.process_market_event(_event("100.30", 1))
+
+    first = coordinator.process_market_event(_event("102.30", 2))
+    audit_count = len(coordinator.audit_transitions)
+    second = coordinator.process_market_event(_event("102.30", 2))
+
+    assert first.state is LifecycleState.CLOSED
+    assert first.exit is not None
+    assert second.exit is first.exit
+    assert len(coordinator.audit_transitions) == audit_count
+    assert [(t.entity_type.value, t.from_state, t.to_state) for t in coordinator.audit_transitions[-2:]] == [
+        ("trade", "open", "closed"),
+        ("position", "open", "closed"),
+    ]
+
+
+def test_expiry_via_time_is_audited() -> None:
+    coordinator = _coordinator()
+    candle = _candle()
+    coordinator.process_evaluation(candle, _evaluation(candle))
+
+    snapshot = coordinator.process_time(datetime(2026, 8, 31, 15, 5, tzinfo=IST))
+
+    assert snapshot.state is LifecycleState.EXPIRED
+    assert coordinator.audit_transitions[-1].to_state == "expired"
+
+
+def test_invalid_market_event_contract_fails_explicitly_when_open() -> None:
+    coordinator = _coordinator()
+    candle = _candle()
+    coordinator.process_evaluation(candle, _evaluation(candle))
+    coordinator.process_market_event(_event("100.30", 1))
+
+    with pytest.raises(ValueError, match="instruments must match"):
+        coordinator.process_market_event(
+            _event("101.00", 2, instrument=InstrumentId("NSE:TCS"))
+        )
+
+
+def test_new_actionable_signal_can_start_after_closed_without_losing_audit_history() -> None:
+    coordinator = _coordinator()
+    candle = _candle()
+    coordinator.process_evaluation(candle, _evaluation(candle))
+    coordinator.process_market_event(_event("100.30", 1))
+    coordinator.process_market_event(_event("102.30", 2))
+    prior_audit_count = len(coordinator.audit_transitions)
+
+    later = _candle(end_minute=5)
+    snapshot = coordinator.process_evaluation(later, _evaluation(later))
+
+    assert snapshot.state is LifecycleState.ARMED
+    assert snapshot.exit is None
+    assert len(coordinator.audit_transitions) == prior_audit_count + 1


### PR DESCRIPTION
## What changed
Implements SF-037, the thin deterministic in-memory coordinator for the M4 lifecycle.

- Adds `LifecycleCoordinator`, `LifecycleState`, and immutable `LifecycleSnapshot`
- Delegates Signal/ARMED logic to `SignalLifecycleManager`
- Delegates paper intent/fill creation to `PaperExecutionPort`
- Delegates Trade/Position open/exit logic to `PositionManager`
- Routes actionable evaluations, ordered MarketEvents, completed-candle boundaries, and session-time inputs
- Tracks composed IDLE/ARMED/TRIGGERED/EXPIRED/OPEN/CLOSED state without re-implementing strategy rules
- Emits deterministic `StateTransition` audit facts for setup, Trade, and Position state changes
- Deduplicates audit facts and preserves idempotency for duplicate inputs
- Blocks pyramiding while OPEN; later actionable evaluations remain diagnostic/non-arming
- Allows a later sequential lifecycle after a prior trade is CLOSED while retaining audit history
- Adds integration coverage for the full coordinator routing and invalid-contract handling

## Scope boundary
No persistence, broker adapter, historical replay framework, or strategy-rule evaluation is added.

Closes #68 when merged.