### PR TITLE
SF-039 — Add deterministic replay input source

### DIFF
--- a/signalforge/runtime/replay.py
+++ b/signalforge/runtime/replay.py
@@ -1,0 +1,108 @@
+"""Deterministic single-security replay input boundary."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from hashlib import sha256
+from json import dumps
+from typing import Protocol
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.market import MarketEvent
+
+
+@dataclass(frozen=True, slots=True)
+class ReplaySourceIdentity:
+    """Deterministic identity and provenance for one normalized replay source."""
+
+    source_id: str
+    instrument_id: InstrumentId
+    event_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayInput:
+    """One canonical replay input exposed to the runtime in deterministic order."""
+
+    event: MarketEvent
+    sequence: int
+    source_id: str
+
+
+class ReplaySource(Protocol):
+    """Iterator-only contract for consuming canonical historical market inputs."""
+
+    @property
+    def identity(self) -> ReplaySourceIdentity: ...
+
+    def __iter__(self) -> Iterator[ReplayInput]: ...
+
+
+class InMemoryReplaySource:
+    """Normalize an in-memory event collection into a deterministic replay stream."""
+
+    def __init__(
+        self,
+        *,
+        instrument_id: InstrumentId,
+        events: Iterable[MarketEvent],
+    ) -> None:
+        indexed_events = tuple(enumerate(events))
+        self._validate_instruments(instrument_id, indexed_events)
+
+        ordered_events = tuple(
+            event
+            for _, event in sorted(
+                indexed_events,
+                key=lambda item: (item[1].exchange_timestamp, item[0]),
+            )
+        )
+        source_id = _source_id(instrument_id, ordered_events)
+        self._identity = ReplaySourceIdentity(
+            source_id=source_id,
+            instrument_id=instrument_id,
+            event_count=len(ordered_events),
+        )
+        self._inputs = tuple(
+            ReplayInput(event=event, sequence=sequence, source_id=source_id)
+            for sequence, event in enumerate(ordered_events)
+        )
+
+    @property
+    def identity(self) -> ReplaySourceIdentity:
+        return self._identity
+
+    def __iter__(self) -> Iterator[ReplayInput]:
+        return iter(self._inputs)
+
+    @staticmethod
+    def _validate_instruments(
+        instrument_id: InstrumentId,
+        indexed_events: tuple[tuple[int, MarketEvent], ...],
+    ) -> None:
+        for _, event in indexed_events:
+            if event.instrument_id != instrument_id:
+                raise ValueError(
+                    "Replay source instrument does not match MarketEvent instrument: "
+                    f"expected {instrument_id}, got {event.instrument_id}"
+                )
+
+
+def _source_id(instrument_id: InstrumentId, events: tuple[MarketEvent, ...]) -> str:
+    payload = {
+        "instrument_id": str(instrument_id),
+        "events": [
+            {
+                "exchange_timestamp": event.exchange_timestamp.isoformat(),
+                "received_timestamp": event.received_timestamp.isoformat(),
+                "price": str(event.price.value),
+                "quantity": event.quantity,
+                "source": event.source,
+                "source_event_id": event.source_event_id,
+            }
+            for event in events
+        ],
+    }
+    encoded = dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return sha256(encoded).hexdigest()

--- a/tests/unit/runtime/test_replay.py
+++ b/tests/unit/runtime/test_replay.py
@@ -1,0 +1,124 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from signalforge.domain.ids import InstrumentId
+from signalforge.domain.market import MarketEvent
+from signalforge.domain.money import Price
+from signalforge.domain.time import IST
+from signalforge.runtime.replay import InMemoryReplaySource, ReplayInput, ReplaySource
+
+INSTRUMENT = InstrumentId("NSE:RELIANCE")
+
+
+def _event(
+    minute: int,
+    *,
+    event_id: str,
+    instrument_id: InstrumentId = INSTRUMENT,
+    price: str = "100.00",
+) -> MarketEvent:
+    exchange_timestamp = datetime(2026, 8, 31, 9, minute, tzinfo=IST)
+    return MarketEvent(
+        instrument_id=instrument_id,
+        exchange_timestamp=exchange_timestamp,
+        received_timestamp=exchange_timestamp + timedelta(milliseconds=1),
+        price=Price(Decimal(price)),
+        quantity=1,
+        source="fixture",
+        source_event_id=event_id,
+    )
+
+
+def _consume(source: ReplaySource) -> list[ReplayInput]:
+    return list(source)
+
+
+def test_orders_by_exchange_timestamp_and_preserves_stable_ties() -> None:
+    late = _event(17, event_id="late")
+    tied_first = _event(16, event_id="tie-first")
+    tied_second = _event(16, event_id="tie-second")
+    early = _event(15, event_id="early")
+
+    source = InMemoryReplaySource(
+        instrument_id=INSTRUMENT,
+        events=(late, tied_first, tied_second, early),
+    )
+
+    inputs = _consume(source)
+    assert [item.event.source_event_id for item in inputs] == [
+        "early",
+        "tie-first",
+        "tie-second",
+        "late",
+    ]
+    assert [item.sequence for item in inputs] == [0, 1, 2, 3]
+
+
+def test_replay_source_identity_is_deterministic_for_same_normalized_stream() -> None:
+    events = (
+        _event(17, event_id="late", price="100.20"),
+        _event(15, event_id="early", price="99.90"),
+    )
+
+    first = InMemoryReplaySource(instrument_id=INSTRUMENT, events=events)
+    second = InMemoryReplaySource(instrument_id=INSTRUMENT, events=tuple(reversed(events)))
+
+    assert first.identity == second.identity
+    assert first.identity.event_count == 2
+    assert all(item.source_id == first.identity.source_id for item in first)
+
+
+def test_source_identity_changes_when_event_provenance_or_payload_changes() -> None:
+    first = InMemoryReplaySource(
+        instrument_id=INSTRUMENT,
+        events=(_event(15, event_id="evt-1", price="100.00"),),
+    )
+    changed = InMemoryReplaySource(
+        instrument_id=INSTRUMENT,
+        events=(_event(15, event_id="evt-2", price="100.00"),),
+    )
+
+    assert first.identity.source_id != changed.identity.source_id
+
+
+def test_rejects_cross_instrument_input() -> None:
+    other = InstrumentId("NSE:TCS")
+
+    with pytest.raises(ValueError, match="instrument does not match"):
+        InMemoryReplaySource(
+            instrument_id=INSTRUMENT,
+            events=(
+                _event(15, event_id="ok"),
+                _event(16, event_id="bad", instrument_id=other),
+            ),
+        )
+
+
+def test_empty_source_is_valid_and_deterministic() -> None:
+    first = InMemoryReplaySource(instrument_id=INSTRUMENT, events=())
+    second = InMemoryReplaySource(instrument_id=INSTRUMENT, events=())
+
+    assert list(first) == []
+    assert first.identity == second.identity
+    assert first.identity.event_count == 0
+
+
+def test_iterator_exposes_events_incrementally_without_peek_api() -> None:
+    source = InMemoryReplaySource(
+        instrument_id=INSTRUMENT,
+        events=(
+            _event(15, event_id="first"),
+            _event(16, event_id="second"),
+        ),
+    )
+
+    stream = iter(source)
+    first = next(stream)
+    assert first.event.source_event_id == "first"
+    assert not hasattr(stream, "peek")
+    second = next(stream)
+    assert second.event.source_event_id == "second"
+    with pytest.raises(StopIteration):
+        next(stream)


### PR DESCRIPTION
## What changed
Implements the M5 replay input boundary for one configured NSE security.

- adds a typed `ReplaySource` protocol
- adds immutable `ReplaySourceIdentity` and `ReplayInput` records
- adds `InMemoryReplaySource` with deterministic ordering by authoritative exchange timestamp
- preserves stable original ordering for equal timestamps
- rejects cross-instrument input
- exposes an iterator-only consumer surface with no peek/future-event API
- computes deterministic source identity from normalized event payload/provenance
- adds focused unit coverage for ordering, identity, provenance, empty sources and contract failures

No strategy logic, database, broker, OpenAlgo, or replay-clock behavior is added.

Closes #94 when merged.