### PR TITLE
SF-040 — Add single-security replay runtime coordinator

### DIFF
--- a/signalforge/runtime/replay_runtime.py
+++ b/signalforge/runtime/replay_runtime.py
@@ -1,0 +1,110 @@
+"""Deterministic single-security in-memory replay runtime composition."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.indicators import IndicatorSnapshot
+from signalforge.domain.instruments import TickSizeSchedule
+from signalforge.domain.market import CompletedCandle
+from signalforge.domain.money import Quantity
+from signalforge.domain.provenance import RunIdentity
+from signalforge.runtime.candles import CandleEngine
+from signalforge.runtime.indicators import IndicatorEngine
+from signalforge.runtime.lifecycle import LifecycleCoordinator, LifecycleSnapshot
+from signalforge.runtime.replay import ReplayInput, ReplaySource
+from signalforge.runtime.strategy_evaluator import (
+    StrategyEvaluationContext,
+    StrategyEvaluator,
+    StrategyEvaluatorResult,
+)
+
+EvaluationContextFactory = Callable[[CompletedCandle], StrategyEvaluationContext]
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayRuntimeStep:
+    """Observable output from processing one replay input."""
+
+    replay_input: ReplayInput
+    completed_candle: CompletedCandle | None
+    indicator_snapshot: IndicatorSnapshot | None
+    evaluation: StrategyEvaluatorResult | None
+    lifecycle: LifecycleSnapshot
+
+
+class ReplayRuntime:
+    """Compose the existing single-security runtime for deterministic replay."""
+
+    def __init__(
+        self,
+        *,
+        source: ReplaySource,
+        run: RunIdentity,
+        tick_schedule: TickSizeSchedule,
+        quantity: Quantity,
+        strategy_config: StrategyV1EvaluationConfig,
+        evaluation_context_factory: EvaluationContextFactory,
+    ) -> None:
+        instrument_id = source.identity.instrument_id
+        if tick_schedule.instrument_id != instrument_id:
+            raise ValueError("Replay source and tick schedule instruments must match")
+
+        self.source = source
+        self.run = run
+        self.candle_engine = CandleEngine(instrument_id=instrument_id)
+        self.indicator_engine = IndicatorEngine(
+            instrument_id,
+            run.engine_calculation_version,
+        )
+        self.strategy_evaluator = StrategyEvaluator(strategy_config)
+        self.lifecycle = LifecycleCoordinator(
+            run=run,
+            tick_schedule=tick_schedule,
+            quantity=quantity,
+        )
+        self._evaluation_context_factory = evaluation_context_factory
+
+    @property
+    def instrument_id(self):
+        return self.source.identity.instrument_id
+
+    def process_input(self, replay_input: ReplayInput) -> ReplayRuntimeStep:
+        """Process one replay input without reading any future source input."""
+
+        if replay_input.source_id != self.source.identity.source_id:
+            raise ValueError("ReplayInput source identity does not match runtime source")
+        event = replay_input.event
+        if event.instrument_id != self.instrument_id:
+            raise ValueError("ReplayInput instrument does not match runtime instrument")
+
+        self.lifecycle.process_market_event(event)
+        completed = self.candle_engine.process(event)
+        if completed is None:
+            return ReplayRuntimeStep(
+                replay_input=replay_input,
+                completed_candle=None,
+                indicator_snapshot=None,
+                evaluation=None,
+                lifecycle=self.lifecycle.snapshot(),
+            )
+
+        self.lifecycle.process_completed_candle(completed)
+        snapshot = self.indicator_engine.update(completed)
+        context = self._evaluation_context_factory(completed)
+        evaluation = self.strategy_evaluator.evaluate(completed, snapshot, context)
+        lifecycle = self.lifecycle.process_evaluation(completed, evaluation)
+        return ReplayRuntimeStep(
+            replay_input=replay_input,
+            completed_candle=completed,
+            indicator_snapshot=snapshot,
+            evaluation=evaluation,
+            lifecycle=lifecycle,
+        )
+
+    def run_all(self) -> tuple[ReplayRuntimeStep, ...]:
+        """Consume the configured replay source serially to exhaustion."""
+
+        return tuple(self.process_input(replay_input) for replay_input in self.source)

--- a/signalforge/runtime/replay_runtime.py
+++ b/signalforge/runtime/replay_runtime.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.ids import InstrumentId
 from signalforge.domain.indicators import IndicatorSnapshot
 from signalforge.domain.instruments import TickSizeSchedule
 from signalforge.domain.market import CompletedCandle
@@ -68,7 +69,7 @@ class ReplayRuntime:
         self._evaluation_context_factory = evaluation_context_factory
 
     @property
-    def instrument_id(self):
+    def instrument_id(self) -> InstrumentId:
         return self.source.identity.instrument_id
 
     def process_input(self, replay_input: ReplayInput) -> ReplayRuntimeStep:

--- a/tests/unit/runtime/test_replay_runtime.py
+++ b/tests/unit/runtime/test_replay_runtime.py
@@ -1,0 +1,167 @@
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from signalforge.config.strategy_v1 import StrategyV1EvaluationConfig
+from signalforge.domain.ids import ConfigId, InstrumentId, RunId
+from signalforge.domain.instruments import TickSizeRule, TickSizeSchedule
+from signalforge.domain.market import MarketEvent
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.time import IST
+from signalforge.runtime.eligibility import MarketDataFeedState
+from signalforge.runtime.indicators import IndicatorContinuity
+from signalforge.runtime.lifecycle import LifecycleState
+from signalforge.runtime.replay import InMemoryReplaySource, ReplayInput
+from signalforge.runtime.replay_runtime import ReplayRuntime
+from signalforge.runtime.strategy_evaluator import StrategyEvaluationContext
+
+INSTRUMENT = InstrumentId("NSE:RELIANCE")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-040"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-040"),
+        config_hash="hash-040",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _schedule(instrument_id: InstrumentId = INSTRUMENT) -> TickSizeSchedule:
+    return TickSizeSchedule(
+        instrument_id=instrument_id,
+        rules=(TickSizeRule(Price(Decimal("0.10")), date(2026, 1, 1)),),
+    )
+
+
+def _event(minute: int, price: str) -> MarketEvent:
+    at = datetime(2026, 8, 31, 10, minute, tzinfo=IST)
+    return MarketEvent(
+        instrument_id=INSTRUMENT,
+        exchange_timestamp=at,
+        received_timestamp=at + timedelta(milliseconds=1),
+        price=Price(Decimal(price)),
+        quantity=1,
+        source="replay-test",
+        source_event_id=f"evt-{minute}-{price}",
+    )
+
+
+def _context_factory(_candle):
+    return StrategyEvaluationContext(
+        completed_regular_session_candles=250,
+        continuity=IndicatorContinuity.HEALTHY,
+        feed_state=MarketDataFeedState.HEALTHY,
+    )
+
+
+def _runtime(events: tuple[MarketEvent, ...]) -> ReplayRuntime:
+    source = InMemoryReplaySource(instrument_id=INSTRUMENT, events=events)
+    return ReplayRuntime(
+        source=source,
+        run=_run(),
+        tick_schedule=_schedule(),
+        quantity=Quantity(10),
+        strategy_config=StrategyV1EvaluationConfig(),
+        evaluation_context_factory=_context_factory,
+    )
+
+
+def test_processes_market_events_and_only_evaluates_completed_candles() -> None:
+    runtime = _runtime((_event(0, "100"), _event(1, "101"), _event(5, "102")))
+
+    steps = runtime.run_all()
+
+    assert len(steps) == 3
+    assert steps[0].completed_candle is None
+    assert steps[0].indicator_snapshot is None
+    assert steps[0].evaluation is None
+    assert steps[1].completed_candle is None
+    assert steps[2].completed_candle is not None
+    assert steps[2].completed_candle.open == Price(Decimal("100"))
+    assert steps[2].completed_candle.close == Price(Decimal("101"))
+    assert steps[2].indicator_snapshot is not None
+    assert steps[2].evaluation is not None
+    assert runtime.indicator_engine.state.ema9.samples == 1
+
+
+def test_runtime_keeps_one_authoritative_lifecycle_instance() -> None:
+    runtime = _runtime((_event(0, "100"), _event(5, "101"), _event(10, "102")))
+
+    steps = runtime.run_all()
+
+    assert all(step.lifecycle.state is LifecycleState.IDLE for step in steps)
+    assert steps[-1].lifecycle == runtime.lifecycle.snapshot()
+
+
+def test_evaluation_context_is_requested_only_for_completed_candles() -> None:
+    calls = []
+
+    def context_factory(candle):
+        calls.append(candle.interval)
+        return _context_factory(candle)
+
+    source = InMemoryReplaySource(
+        instrument_id=INSTRUMENT,
+        events=(_event(0, "100"), _event(1, "101"), _event(5, "102")),
+    )
+    runtime = ReplayRuntime(
+        source=source,
+        run=_run(),
+        tick_schedule=_schedule(),
+        quantity=Quantity(10),
+        strategy_config=StrategyV1EvaluationConfig(),
+        evaluation_context_factory=context_factory,
+    )
+
+    runtime.run_all()
+
+    assert len(calls) == 1
+
+
+def test_rejects_tick_schedule_for_different_instrument() -> None:
+    source = InMemoryReplaySource(instrument_id=INSTRUMENT, events=())
+
+    with pytest.raises(ValueError, match="tick schedule instruments must match"):
+        ReplayRuntime(
+            source=source,
+            run=_run(),
+            tick_schedule=_schedule(InstrumentId("NSE:TCS")),
+            quantity=Quantity(10),
+            strategy_config=StrategyV1EvaluationConfig(),
+            evaluation_context_factory=_context_factory,
+        )
+
+
+def test_rejects_replay_input_from_different_source_identity() -> None:
+    runtime = _runtime((_event(0, "100"),))
+    foreign_source = InMemoryReplaySource(instrument_id=INSTRUMENT, events=(_event(1, "101"),))
+    foreign_input = next(iter(foreign_source))
+
+    with pytest.raises(ValueError, match="source identity"):
+        runtime.process_input(foreign_input)
+
+
+def test_process_input_is_serial_and_does_not_consume_future_source_items() -> None:
+    events = (_event(0, "100"), _event(5, "101"))
+    source = InMemoryReplaySource(instrument_id=INSTRUMENT, events=events)
+    runtime = ReplayRuntime(
+        source=source,
+        run=_run(),
+        tick_schedule=_schedule(),
+        quantity=Quantity(10),
+        strategy_config=StrategyV1EvaluationConfig(),
+        evaluation_context_factory=_context_factory,
+    )
+    iterator = iter(source)
+    first: ReplayInput = next(iterator)
+
+    step = runtime.process_input(first)
+
+    assert step.replay_input.sequence == 0
+    assert runtime.candle_engine.active_interval is not None
+    assert runtime.indicator_engine.state.ema9.samples == 0
+    assert next(iterator).sequence == 1


### PR DESCRIPTION
## What changed
Implements the M5 in-memory single-security replay runtime coordinator.

- composes ReplaySource, CandleEngine, IndicatorEngine, StrategyEvaluator, and LifecycleCoordinator
- routes every ordered market event through lifecycle handling before candle completion
- advances indicators and strategy evaluation only from completed canonical candles
- injects evaluation context externally so SF-040 does not invent replay-clock/session-count semantics
- exposes deterministic per-input ReplayRuntimeStep outputs
- preserves one authoritative in-memory runtime state per configured instrument
- rejects source/tick-schedule/instrument mismatches
- adds focused unit coverage for serial processing, completed-candle-only evaluation, context routing, and no future-source consumption

No persistence, broker/OpenAlgo integration, replay clock, or multi-security orchestration is added.

Closes #95 when merged.