### PR TITLE
Demo — Run replay CLI in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Install project and development dependencies
         run: python -m pip install --upgrade pip && python -m pip install -e '.[dev]'
 
+      - name: Replay CLI smoke demonstration
+        run: |
+          echo '$ signalforge replay --config examples/replay/replay-config.json --input examples/replay/replay-events.json'
+          signalforge replay --config examples/replay/replay-config.json --input examples/replay/replay-events.json
+
       - name: Ruff
         run: ruff check .
 

--- a/examples/replay/replay-config.json
+++ b/examples/replay/replay-config.json
@@ -1,0 +1,12 @@
+{
+  "instrument_id": "NSE:RELIANCE",
+  "quantity": 10,
+  "engine_calculation_version": "engine-v1",
+  "tick_rules": [
+    {
+      "tick_size": "0.10",
+      "effective_from": "2026-01-01"
+    }
+  ],
+  "strategy": {}
+}

--- a/examples/replay/replay-events.json
+++ b/examples/replay/replay-events.json
@@ -1,0 +1,26 @@
+[
+  {
+    "exchange_timestamp": "2026-08-31T10:00:00+05:30",
+    "received_timestamp": "2026-08-31T10:00:00.001+05:30",
+    "price": "100.00",
+    "quantity": 1,
+    "source": "demo",
+    "source_event_id": "e1"
+  },
+  {
+    "exchange_timestamp": "2026-08-31T10:01:00+05:30",
+    "received_timestamp": "2026-08-31T10:01:00.001+05:30",
+    "price": "100.20",
+    "quantity": 1,
+    "source": "demo",
+    "source_event_id": "e2"
+  },
+  {
+    "exchange_timestamp": "2026-08-31T10:05:00+05:30",
+    "received_timestamp": "2026-08-31T10:05:00.001+05:30",
+    "price": "100.10",
+    "quantity": 1,
+    "source": "demo",
+    "source_event_id": "e3"
+  }
+]


### PR DESCRIPTION
Temporary demonstration branch showing the runnable replay CLI with concrete input files and actual GitHub Actions output. Closed without merge after validating the command surface. The useful fixture/demo pattern will be carried forward into SF-043 as a proper deterministic golden-session fixture.

No strategy or runtime behavior changes were intended for merge.