### PR TITLE
SF-043 — Add M5 replay golden-session determinism tests

### DIFF
--- a/examples/replay/golden-config.json
+++ b/examples/replay/golden-config.json
@@ -1,0 +1,12 @@
+{
+  "instrument_id": "NSE:RELIANCE",
+  "quantity": 10,
+  "engine_calculation_version": "engine-v1",
+  "tick_rules": [
+    {
+      "tick_size": "0.10",
+      "effective_from": "2026-01-01"
+    }
+  ],
+  "strategy": {}
+}

--- a/tests/integration/runtime/test_replay_golden_session.py
+++ b/tests/integration/runtime/test_replay_golden_session.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from signalforge.cli import replay_command
 from signalforge.domain.time import IST
@@ -159,5 +160,5 @@ def test_malformed_replay_input_fails_explicitly(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         replay_command(CONFIG, malformed)

--- a/tests/integration/runtime/test_replay_golden_session.py
+++ b/tests/integration/runtime/test_replay_golden_session.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from signalforge.cli import replay_command
+from signalforge.domain.time import IST
+
+CONFIG = Path("examples/replay/golden-config.json")
+SESSION_DATES = (
+    date(2026, 8, 26),
+    date(2026, 8, 27),
+    date(2026, 8, 28),
+    date(2026, 8, 31),
+)
+_PATTERN = (
+    Decimal("0.6"),
+    Decimal("-0.4"),
+    Decimal("0.6"),
+    Decimal("-0.4"),
+    Decimal("0.2"),
+)
+
+
+def _golden_closes() -> list[Decimal]:
+    closes = [Decimal("100.0")]
+    switch = 271
+    for index in range(1, 300):
+        delta = (
+            Decimal("0.2")
+            if index < switch
+            else _PATTERN[(index - switch + 1) % len(_PATTERN)]
+        )
+        closes.append(closes[-1] + delta)
+
+    # The accepted V1 rules first qualify on the final session's 14:55-15:00 candle.
+    # Subsequent observed prices trigger the setup, stay inside stop/target, then provide
+    # the first real trade/LTP at 15:15 for the forced-session exit.
+    closes[294:] = [
+        Decimal("156.3"),
+        Decimal("156.6"),
+        Decimal("156.6"),
+        Decimal("156.7"),
+        Decimal("156.7"),
+        Decimal("156.7"),
+    ]
+    return closes
+
+
+def _event_payload(at: datetime, price: Decimal, source_event_id: str) -> dict[str, object]:
+    return {
+        "exchange_timestamp": at.isoformat(),
+        "received_timestamp": (at + timedelta(milliseconds=1)).isoformat(),
+        "price": format(price, "f"),
+        "quantity": 1,
+        "source": "golden-fixture",
+        "source_event_id": source_event_id,
+    }
+
+
+def _golden_events() -> list[dict[str, object]]:
+    closes = _golden_closes()
+    events: list[dict[str, object]] = []
+    index = 0
+
+    for session_date in SESSION_DATES:
+        start = datetime.combine(session_date, datetime.min.time(), tzinfo=IST).replace(
+            hour=9,
+            minute=15,
+        )
+        for candle_index in range(75):
+            at = start + timedelta(minutes=5 * candle_index)
+            events.append(_event_payload(at, closes[index], f"g{index:03d}"))
+            if index == 294:
+                events.append(
+                    _event_payload(
+                        at + timedelta(seconds=1),
+                        Decimal("156.5"),
+                        "g-trigger",
+                    )
+                )
+            index += 1
+
+    # Completes the final 15:25-15:30 regular-session candle. The newly active
+    # 15:30 interval is never emitted, so no post-session candle is invented.
+    final_boundary = datetime(2026, 8, 31, 15, 30, tzinfo=IST)
+    events.append(
+        _event_payload(final_boundary, Decimal("156.7"), "g-final-boundary")
+    )
+    return events
+
+
+def _write_events(tmp_path: Path, events: list[dict[str, object]]) -> Path:
+    path = tmp_path / "golden-events.json"
+    path.write_text(json.dumps(events, indent=2), encoding="utf-8")
+    return path
+
+
+def test_complete_session_replay_produces_one_closed_trade_deterministically(
+    tmp_path: Path,
+) -> None:
+    events_path = _write_events(tmp_path, _golden_events())
+
+    first = replay_command(CONFIG, events_path)
+    second = replay_command(CONFIG, events_path)
+
+    assert first == second
+    assert first["events"] == 302
+    assert first["evaluations"] == 300
+    assert first["signals"] == 1
+    assert first["trades"] == 1
+    assert first["exits"] == 1
+    assert first["open_rejections"] == 0
+    assert first["qualified"] == 1
+    assert first["actionable"] == 1
+    assert first["final_lifecycle_state"] == "closed"
+    assert first["run_id"] == second["run_id"]
+    assert first["source_id"] == second["source_id"]
+
+
+def test_overnight_gaps_do_not_create_synthetic_completed_candles(tmp_path: Path) -> None:
+    events_path = _write_events(tmp_path, _golden_events())
+
+    summary = replay_command(CONFIG, events_path)
+
+    # Four complete regular sessions x 75 five-minute candles.
+    assert summary["evaluations"] == 300
+    assert summary["events"] == 302
+
+
+def test_golden_fixture_has_no_pre_signal_actionable_decisions(tmp_path: Path) -> None:
+    events_path = _write_events(tmp_path, _golden_events())
+
+    summary = replay_command(CONFIG, events_path)
+
+    assert summary["qualified"] == 1
+    assert summary["actionable"] == 1
+    assert summary["signals"] == 1
+
+
+def test_malformed_replay_input_fails_explicitly(tmp_path: Path) -> None:
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text(
+        json.dumps(
+            [
+                {
+                    "exchange_timestamp": "not-a-timestamp",
+                    "received_timestamp": "2026-08-31T10:00:00.001+05:30",
+                    "price": "100.00",
+                    "quantity": 1,
+                    "source": "malformed",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(Exception):
+        replay_command(CONFIG, malformed)


### PR DESCRIPTION
## What changed
Implements the M5 replay integration gate.

- adds a permanent `examples/replay/golden-config.json` fixture
- adds a deterministic four-session replay fixture generator (300 completed 5-minute NSE regular-session candles)
- preserves the accepted 250-candle warmup rather than bypassing it
- creates exactly one qualifying/actionable V1 setup on the final session's 14:55–15:00 candle
- uses an observed 15:00:01 trigger trade/LTP and observed 15:15 trade/LTP for forced-session closure
- asserts repeated identical replay produces identical summary, run identity, source identity, and lifecycle outcome
- asserts overnight gaps create no synthetic completed candles
- asserts malformed replay input fails explicitly

Existing SF-039/SF-041 tests continue to cover stable input ordering, non-decreasing replay chronology, no-look-ahead, 15:05 cutoff, and event-driven 15:15 forced exit semantics.

No strategy semantics are changed.

Closes #98 when merged.