### PR TITLE
SF-045A — Persistence contracts, canonical identity and lossless mapping

### DIFF
--- a/alembic/versions/20260901_0002_preserve_realised_r_precision.py
+++ b/alembic/versions/20260901_0002_preserve_realised_r_precision.py
@@ -1,0 +1,40 @@
+"""Store realised R without an arbitrary fractional scale limit.
+
+Revision ID: 20260901_0002
+Revises: 20260831_0001
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260901_0002"
+down_revision: str | None = "20260831_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Remove the scale limit that could round valid finite domain Decimals."""
+    op.alter_column(
+        "exits",
+        "realised_r",
+        existing_type=sa.Numeric(38, 18),
+        type_=sa.Numeric(),
+        existing_nullable=False,
+        postgresql_using="realised_r::numeric",
+    )
+
+
+def downgrade() -> None:
+    """Restore the SF-044 bounded realised-R representation."""
+    op.alter_column(
+        "exits",
+        "realised_r",
+        existing_type=sa.Numeric(),
+        type_=sa.Numeric(38, 18),
+        postgresql_using="realised_r::numeric(38, 18)",
+        existing_nullable=False,
+    )

--- a/docs/persistence-development.md
+++ b/docs/persistence-development.md
@@ -67,3 +67,37 @@ The initial schema implements ADR-003's hybrid model:
 CI starts a clean PostgreSQL service, runs `alembic upgrade head`, then runs the normal test suite.
 Migration integration tests also verify that the initial revision can downgrade to `base` and
 re-upgrade to `head` reproducibly.
+
+
+## SF-045A fidelity contracts
+
+Repository contracts in `signalforge.persistence.contracts` are SQL-free. SQLAlchemy records remain
+behind explicit Data Mappers, and later PostgreSQL adapters receive transaction ownership from their
+caller.
+
+All price/economic columns retain SF-044's `NUMERIC(38,18)` representation except
+`exits.realised_r`. The Exit domain accepts any finite Decimal and defines no 40-fractional-digit
+bound, so a fixed scale such as `NUMERIC(80,40)` would still round valid values. Realised R therefore
+uses unconstrained PostgreSQL `NUMERIC`, preserving its decimal coefficient without imposing an
+unaccepted domain precision rule.
+
+### Deterministic identity compatibility
+
+Before SF-045A, affected timestamp components used direct `datetime.isoformat()`. That retained
+the source UTC offset and representation, so two aware datetimes for the same instant could hash
+differently. SF-045A converts the instant to UTC and emits a fixed-microsecond form such as
+`2026-08-31T04:30:00.000000Z`. Naive timestamps remain invalid.
+
+Affected Decimal components previously used `str(Decimal)`, retaining trailing-zero exponents,
+exponent notation, and the sign of zero. SF-045A emits finite Decimals in fixed-point notation,
+removes only insignificant fractional zeros, and maps `0`, `-0`, `0.000`, and `-0.000` to `0`.
+Non-zero values are never rounded, including values exceeding the active Decimal context precision.
+The valid TriggerEvent, Fill, and MarketEvent domains require strictly positive prices, so signed
+zero is rejected before those domain facts can be created; the shared canonical encoding still
+defines signed-zero behavior explicitly.
+
+Direct IDs for Signal, TriggerEvent, Fill, and generated exit fills can change. EntryIntent, Trade,
+Position, Exit, and StateTransition IDs can also change transitively when they include or reference
+one of those changed IDs. This is acceptable because no production persistence or restart-compatible
+ID history exists before M6. No historical-ID migration or recovery compatibility path is required
+or introduced.

--- a/signalforge/domain/execution.py
+++ b/signalforge/domain/execution.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 
+from signalforge.domain.identity import canonical_decimal, canonical_timestamp
 from signalforge.domain.ids import (
     EntryIntentId,
     FillId,
@@ -60,8 +61,8 @@ class TriggerEvent:
             TriggerEventId,
             str(run.run_id),
             str(signal_id),
-            observed_at.isoformat(),
-            str(observed_price.value),
+            canonical_timestamp(observed_at),
+            canonical_decimal(observed_price.value),
         )
         return cls(
             trigger_event_id=event_id,
@@ -78,8 +79,8 @@ class TriggerEvent:
             TriggerEventId,
             str(self.run.run_id),
             str(self.signal_id),
-            self.observed_at.isoformat(),
-            str(self.observed_price.value),
+            canonical_timestamp(self.observed_at),
+            canonical_decimal(self.observed_price.value),
         )
 
 
@@ -190,8 +191,8 @@ class Fill:
             FillId,
             str(run.run_id),
             str(entry_intent_id),
-            filled_at.isoformat(),
-            str(fill_price.value),
+            canonical_timestamp(filled_at),
+            canonical_decimal(fill_price.value),
             str(quantity.value),
         )
         return cls(
@@ -213,7 +214,7 @@ class Fill:
             FillId,
             str(self.run.run_id),
             str(self.entry_intent_id),
-            self.filled_at.isoformat(),
-            str(self.fill_price.value),
+            canonical_timestamp(self.filled_at),
+            canonical_decimal(self.fill_price.value),
             str(self.quantity.value),
         )

--- a/signalforge/domain/identity.py
+++ b/signalforge/domain/identity.py
@@ -1,0 +1,27 @@
+"""Canonical, representation-independent encoding for deterministic identities."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+
+def canonical_timestamp(value: datetime) -> str:
+    """Encode an aware instant in UTC without representation-dependent offset data."""
+
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("identity timestamps must be timezone-aware")
+    return value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def canonical_decimal(value: Decimal) -> str:
+    """Encode a finite Decimal without insignificant trailing zeros or rounding."""
+
+    if not value.is_finite():
+        raise ValueError("identity Decimals must be finite")
+    if value.is_zero():
+        return "0"
+    encoded = format(value, "f")
+    if "." in encoded:
+        encoded = encoded.rstrip("0").rstrip(".")
+    return encoded

--- a/signalforge/domain/signals.py
+++ b/signalforge/domain/signals.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
+from signalforge.domain.identity import canonical_timestamp
 from signalforge.domain.ids import InstrumentId, SignalId, deterministic_id
 from signalforge.domain.money import Price
 from signalforge.domain.provenance import RunIdentity
@@ -51,8 +52,8 @@ class Signal:
             SignalId,
             str(run.run_id),
             str(instrument_id),
-            interval.start.isoformat(),
-            interval.end.isoformat(),
+            canonical_timestamp(interval.start),
+            canonical_timestamp(interval.end),
         )
         return cls(
             signal_id=signal_id,
@@ -71,6 +72,6 @@ class Signal:
             SignalId,
             str(self.run.run_id),
             str(self.instrument_id),
-            self.interval.start.isoformat(),
-            self.interval.end.isoformat(),
+            canonical_timestamp(self.interval.start),
+            canonical_timestamp(self.interval.end),
         )

--- a/signalforge/persistence/contracts.py
+++ b/signalforge/persistence/contracts.py
@@ -1,0 +1,103 @@
+"""SQL-agnostic repository contracts for canonical M6 persistence."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from signalforge.domain.armed import ArmedSetup
+from signalforge.domain.audit import StateTransition
+from signalforge.domain.execution import EntryIntent, Fill, TriggerEvent
+from signalforge.domain.exits import Exit
+from signalforge.domain.ids import (
+    EntryIntentId,
+    ExitId,
+    FillId,
+    InstrumentId,
+    PositionId,
+    RunId,
+    SignalId,
+    StateTransitionId,
+    TradeId,
+    TriggerEventId,
+)
+from signalforge.domain.positions import Position
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.strategy import StrategyEvaluation
+from signalforge.domain.time import CandleInterval
+from signalforge.domain.trades import Trade
+
+
+class RunProvenanceRepository(Protocol):
+    """Persist immutable strategy/config/run provenance."""
+
+    def add(self, run: RunIdentity) -> RunIdentity: ...
+
+    def get(self, run_id: RunId) -> RunIdentity | None: ...
+
+
+class StrategyEvaluationRepository(Protocol):
+    """Persist immutable run-scoped strategy decisions."""
+
+    def append(self, run_id: RunId, evaluation: StrategyEvaluation) -> StrategyEvaluation: ...
+
+    def get(
+        self,
+        run_id: RunId,
+        instrument_id: InstrumentId,
+        interval: CandleInterval,
+    ) -> StrategyEvaluation | None: ...
+
+
+class SignalRepository(Protocol):
+    def append(self, signal: Signal) -> Signal: ...
+
+    def get(self, signal_id: SignalId) -> Signal | None: ...
+
+
+class ArmedSetupRepository(Protocol):
+    def upsert(self, run_id: RunId, setup: ArmedSetup) -> ArmedSetup: ...
+
+    def get(self, signal_id: SignalId) -> ArmedSetup | None: ...
+
+
+class TriggerEventRepository(Protocol):
+    def append(self, event: TriggerEvent) -> TriggerEvent: ...
+
+    def get(self, event_id: TriggerEventId) -> TriggerEvent | None: ...
+
+
+class EntryIntentRepository(Protocol):
+    def append(self, intent: EntryIntent) -> EntryIntent: ...
+
+    def get(self, intent_id: EntryIntentId) -> EntryIntent | None: ...
+
+
+class FillRepository(Protocol):
+    def append(self, fill: Fill) -> Fill: ...
+
+    def get(self, fill_id: FillId) -> Fill | None: ...
+
+
+class TradeRepository(Protocol):
+    def upsert(self, trade: Trade) -> Trade: ...
+
+    def get(self, trade_id: TradeId) -> Trade | None: ...
+
+
+class PositionRepository(Protocol):
+    def upsert(self, position: Position) -> Position: ...
+
+    def get(self, position_id: PositionId) -> Position | None: ...
+
+
+class ExitRepository(Protocol):
+    def append(self, exit_fact: Exit) -> Exit: ...
+
+    def get(self, exit_id: ExitId) -> Exit | None: ...
+
+
+class StateTransitionRepository(Protocol):
+    def append(self, transition: StateTransition) -> StateTransition: ...
+
+    def get(self, transition_id: StateTransitionId) -> StateTransition | None: ...

--- a/signalforge/persistence/errors.py
+++ b/signalforge/persistence/errors.py
@@ -1,0 +1,17 @@
+"""SQL-free errors exposed by the SignalForge persistence boundary."""
+
+
+class PersistenceError(RuntimeError):
+    """Base error for persistence-boundary failures."""
+
+
+class PersistenceConflictError(PersistenceError):
+    """Stored state contradicts the requested logical write."""
+
+
+class ContradictoryFactError(PersistenceConflictError):
+    """An immutable logical identity is already bound to different facts."""
+
+
+class PersistenceDependencyError(PersistenceError):
+    """A required persisted parent or provenance record is absent."""

--- a/signalforge/persistence/mappers.py
+++ b/signalforge/persistence/mappers.py
@@ -1,0 +1,394 @@
+"""Explicit Data Mappers between domain/runtime objects and SQLAlchemy records."""
+
+from __future__ import annotations
+
+from signalforge.domain.armed import ArmedSetup, ArmedSetupState, ExpiryReason
+from signalforge.domain.audit import StateTransition, TransitionEntityType
+from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, TriggerEvent
+from signalforge.domain.exits import Exit, ExitReason
+from signalforge.domain.ids import (
+    ConfigId,
+    EntryIntentId,
+    ExitId,
+    FillId,
+    InstrumentId,
+    PositionId,
+    RunId,
+    SignalId,
+    StateTransitionId,
+    TradeId,
+    TriggerEventId,
+)
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.positions import Position, PositionState
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.strategy import (
+    DecisionReason,
+    MomentumResult,
+    SetupResult,
+    StrategyEvaluation,
+    TrendResult,
+)
+from signalforge.domain.time import CandleInterval
+from signalforge.domain.trades import Trade, TradeState
+from signalforge.persistence.models import (
+    ArmedSetupRecord,
+    EntryIntentRecord,
+    ExitRecord,
+    FillRecord,
+    PositionRecord,
+    RunRecord,
+    SignalRecord,
+    StateTransitionRecord,
+    StrategyConfigRecord,
+    StrategyEvaluationRecord,
+    TradeRecord,
+    TriggerEventRecord,
+)
+
+
+def strategy_config_record_from_domain(run: RunIdentity) -> StrategyConfigRecord:
+    return StrategyConfigRecord(
+        config_id=str(run.config_id),
+        strategy_id=run.strategy.strategy_id,
+        strategy_version=run.strategy.strategy_version,
+        config_hash=run.config_hash,
+    )
+
+
+def run_record_from_domain(run: RunIdentity) -> RunRecord:
+    return RunRecord(
+        run_id=str(run.run_id),
+        config_id=str(run.config_id),
+        engine_calculation_version=run.engine_calculation_version,
+    )
+
+
+def run_identity_from_records(
+    run: RunRecord,
+    config: StrategyConfigRecord,
+) -> RunIdentity:
+    if run.config_id != config.config_id:
+        raise ValueError("RunRecord and StrategyConfigRecord config identities do not match")
+    return RunIdentity(
+        run_id=RunId(run.run_id),
+        strategy=StrategyIdentity(config.strategy_id, config.strategy_version),
+        config_id=ConfigId(config.config_id),
+        config_hash=config.config_hash,
+        engine_calculation_version=run.engine_calculation_version,
+    )
+
+
+def strategy_evaluation_record_from_domain(
+    run_id: RunId,
+    evaluation: StrategyEvaluation,
+) -> StrategyEvaluationRecord:
+    return StrategyEvaluationRecord(
+        run_id=str(run_id),
+        instrument_id=str(evaluation.instrument_id),
+        interval_start=evaluation.interval.start,
+        interval_end=evaluation.interval.end,
+        trend_passed=evaluation.trend.passed,
+        momentum_passed=evaluation.momentum.passed,
+        rsi_passed=evaluation.momentum.rsi_passed,
+        adx_passed=evaluation.momentum.adx_passed,
+        macd_signal_positive=evaluation.momentum.macd_signal_positive,
+        setup_passed=evaluation.setup.passed,
+        qualified=evaluation.qualified,
+        actionable=evaluation.actionable,
+        reasons=[reason.value for reason in evaluation.reasons],
+    )
+
+
+def strategy_evaluation_from_record(record: StrategyEvaluationRecord) -> StrategyEvaluation:
+    return StrategyEvaluation(
+        instrument_id=InstrumentId(record.instrument_id),
+        interval=CandleInterval(record.interval_start, record.interval_end),
+        trend=TrendResult(record.trend_passed),
+        momentum=MomentumResult(
+            passed=record.momentum_passed,
+            rsi_passed=record.rsi_passed,
+            adx_passed=record.adx_passed,
+            macd_signal_positive=record.macd_signal_positive,
+        ),
+        setup=SetupResult(record.setup_passed),
+        qualified=record.qualified,
+        actionable=record.actionable,
+        reasons=tuple(DecisionReason(value) for value in record.reasons),
+    )
+
+
+def signal_record_from_domain(signal: Signal) -> SignalRecord:
+    return SignalRecord(
+        signal_id=str(signal.signal_id),
+        run_id=str(signal.run.run_id),
+        instrument_id=str(signal.instrument_id),
+        interval_start=signal.interval.start,
+        interval_end=signal.interval.end,
+        signal_close=signal.signal_close.value,
+        signal_low=signal.signal_low.value,
+        created_at=signal.created_at,
+    )
+
+
+def signal_from_record(record: SignalRecord, run: RunIdentity) -> Signal:
+    return Signal(
+        signal_id=SignalId(record.signal_id),
+        instrument_id=InstrumentId(record.instrument_id),
+        interval=CandleInterval(record.interval_start, record.interval_end),
+        signal_close=Price(record.signal_close),
+        signal_low=Price(record.signal_low),
+        run=run,
+        created_at=record.created_at,
+    )
+
+
+def armed_setup_record_from_domain(run_id: RunId, setup: ArmedSetup) -> ArmedSetupRecord:
+    return ArmedSetupRecord(
+        signal_id=str(setup.signal_id),
+        run_id=str(run_id),
+        raw_trigger=setup.raw_trigger.value,
+        tradable_trigger=setup.tradable_trigger.value,
+        signal_low=setup.signal_low.value,
+        armed_at=setup.armed_at,
+        valid_until=setup.valid_until,
+        state=setup.state.value,
+        terminal_at=setup.terminal_at,
+        expiry_reason=None if setup.expiry_reason is None else setup.expiry_reason.value,
+    )
+
+
+def armed_setup_from_record(record: ArmedSetupRecord) -> ArmedSetup:
+    return ArmedSetup(
+        signal_id=SignalId(record.signal_id),
+        raw_trigger=Price(record.raw_trigger),
+        tradable_trigger=Price(record.tradable_trigger),
+        signal_low=Price(record.signal_low),
+        armed_at=record.armed_at,
+        valid_until=record.valid_until,
+        state=ArmedSetupState(record.state),
+        terminal_at=record.terminal_at,
+        expiry_reason=None if record.expiry_reason is None else ExpiryReason(record.expiry_reason),
+    )
+
+
+def trigger_event_record_from_domain(event: TriggerEvent) -> TriggerEventRecord:
+    return TriggerEventRecord(
+        trigger_event_id=str(event.trigger_event_id),
+        signal_id=str(event.signal_id),
+        run_id=str(event.run.run_id),
+        instrument_id=str(event.instrument_id),
+        reference_price=event.reference_price.value,
+        observed_price=event.observed_price.value,
+        observed_at=event.observed_at,
+    )
+
+
+def trigger_event_from_record(record: TriggerEventRecord, run: RunIdentity) -> TriggerEvent:
+    return TriggerEvent(
+        trigger_event_id=TriggerEventId(record.trigger_event_id),
+        signal_id=SignalId(record.signal_id),
+        instrument_id=InstrumentId(record.instrument_id),
+        reference_price=Price(record.reference_price),
+        observed_price=Price(record.observed_price),
+        observed_at=record.observed_at,
+        run=run,
+    )
+
+
+def entry_intent_record_from_domain(intent: EntryIntent) -> EntryIntentRecord:
+    return EntryIntentRecord(
+        entry_intent_id=str(intent.entry_intent_id),
+        trigger_event_id=str(intent.trigger_event_id),
+        signal_id=str(intent.signal_id),
+        run_id=str(intent.run.run_id),
+        instrument_id=str(intent.instrument_id),
+        reference_price=intent.reference_price.value,
+        quantity=intent.quantity.value,
+        execution_mode=intent.execution_mode.value,
+        created_at=intent.created_at,
+    )
+
+
+def entry_intent_from_record(record: EntryIntentRecord, run: RunIdentity) -> EntryIntent:
+    return EntryIntent(
+        entry_intent_id=EntryIntentId(record.entry_intent_id),
+        trigger_event_id=TriggerEventId(record.trigger_event_id),
+        signal_id=SignalId(record.signal_id),
+        instrument_id=InstrumentId(record.instrument_id),
+        reference_price=Price(record.reference_price),
+        quantity=Quantity(record.quantity),
+        execution_mode=ExecutionMode(record.execution_mode),
+        created_at=record.created_at,
+        run=run,
+    )
+
+
+def fill_record_from_domain(fill: Fill) -> FillRecord:
+    return FillRecord(
+        fill_id=str(fill.fill_id),
+        entry_intent_id=str(fill.entry_intent_id),
+        trigger_event_id=str(fill.trigger_event_id),
+        signal_id=str(fill.signal_id),
+        run_id=str(fill.run.run_id),
+        instrument_id=str(fill.instrument_id),
+        reference_price=fill.reference_price.value,
+        fill_price=fill.fill_price.value,
+        quantity=fill.quantity.value,
+        execution_mode=fill.execution_mode.value,
+        filled_at=fill.filled_at,
+    )
+
+
+def fill_from_record(record: FillRecord, run: RunIdentity) -> Fill:
+    return Fill(
+        fill_id=FillId(record.fill_id),
+        entry_intent_id=EntryIntentId(record.entry_intent_id),
+        trigger_event_id=TriggerEventId(record.trigger_event_id),
+        signal_id=SignalId(record.signal_id),
+        instrument_id=InstrumentId(record.instrument_id),
+        reference_price=Price(record.reference_price),
+        fill_price=Price(record.fill_price),
+        quantity=Quantity(record.quantity),
+        execution_mode=ExecutionMode(record.execution_mode),
+        filled_at=record.filled_at,
+        run=run,
+    )
+
+
+def trade_record_from_domain(trade: Trade) -> TradeRecord:
+    return TradeRecord(
+        trade_id=str(trade.trade_id),
+        entry_fill_id=str(trade.entry_fill_id),
+        signal_id=str(trade.signal_id),
+        run_id=str(trade.run.run_id),
+        instrument_id=str(trade.instrument_id),
+        entry_price=trade.entry_price.value,
+        stop_price=trade.stop_price.value,
+        raw_target_price=trade.raw_target_price.value,
+        tradable_target_price=trade.tradable_target_price.value,
+        risk_per_share=trade.risk_per_share.value,
+        quantity=trade.quantity.value,
+        opened_at=trade.opened_at,
+        state=trade.state.value,
+        closed_at=trade.closed_at,
+        exit_id=None if trade.exit_id is None else str(trade.exit_id),
+    )
+
+
+def trade_from_record(record: TradeRecord, run: RunIdentity) -> Trade:
+    return Trade(
+        trade_id=TradeId(record.trade_id),
+        entry_fill_id=FillId(record.entry_fill_id),
+        signal_id=SignalId(record.signal_id),
+        instrument_id=InstrumentId(record.instrument_id),
+        entry_price=Price(record.entry_price),
+        stop_price=Price(record.stop_price),
+        raw_target_price=Price(record.raw_target_price),
+        tradable_target_price=Price(record.tradable_target_price),
+        risk_per_share=Price(record.risk_per_share),
+        quantity=Quantity(record.quantity),
+        opened_at=record.opened_at,
+        run=run,
+        state=TradeState(record.state),
+        closed_at=record.closed_at,
+        exit_id=None if record.exit_id is None else ExitId(record.exit_id),
+    )
+
+
+def position_record_from_domain(position: Position) -> PositionRecord:
+    return PositionRecord(
+        position_id=str(position.position_id),
+        trade_id=str(position.trade_id),
+        run_id=str(position.run.run_id),
+        instrument_id=str(position.instrument_id),
+        quantity=position.quantity.value,
+        average_entry_price=position.average_entry_price.value,
+        opened_at=position.opened_at,
+        state=position.state.value,
+        closed_at=position.closed_at,
+    )
+
+
+def position_from_record(record: PositionRecord, run: RunIdentity) -> Position:
+    return Position(
+        position_id=PositionId(record.position_id),
+        trade_id=TradeId(record.trade_id),
+        instrument_id=InstrumentId(record.instrument_id),
+        quantity=Quantity(record.quantity),
+        average_entry_price=Price(record.average_entry_price),
+        opened_at=record.opened_at,
+        run=run,
+        state=PositionState(record.state),
+        closed_at=record.closed_at,
+    )
+
+
+def exit_record_from_domain(exit_fact: Exit) -> ExitRecord:
+    return ExitRecord(
+        exit_id=str(exit_fact.exit_id),
+        exit_fill_id=str(exit_fact.exit_fill_id),
+        trade_id=str(exit_fact.trade_id),
+        position_id=str(exit_fact.position_id),
+        run_id=str(exit_fact.run.run_id),
+        instrument_id=str(exit_fact.instrument_id),
+        reason=exit_fact.reason.value,
+        reference_price=exit_fact.reference_price.value,
+        fill_price=exit_fact.fill_price.value,
+        quantity=exit_fact.quantity.value,
+        execution_mode=exit_fact.execution_mode.value,
+        exited_at=exit_fact.exited_at,
+        realised_pnl=exit_fact.realised_pnl,
+        realised_r=exit_fact.realised_r,
+    )
+
+
+def exit_from_record(record: ExitRecord, run: RunIdentity) -> Exit:
+    return Exit(
+        exit_id=ExitId(record.exit_id),
+        exit_fill_id=FillId(record.exit_fill_id),
+        trade_id=TradeId(record.trade_id),
+        position_id=PositionId(record.position_id),
+        instrument_id=InstrumentId(record.instrument_id),
+        reason=ExitReason(record.reason),
+        reference_price=Price(record.reference_price),
+        fill_price=Price(record.fill_price),
+        quantity=Quantity(record.quantity),
+        execution_mode=ExecutionMode(record.execution_mode),
+        exited_at=record.exited_at,
+        realised_pnl=record.realised_pnl,
+        realised_r=record.realised_r,
+        run=run,
+    )
+
+
+def state_transition_record_from_domain(transition: StateTransition) -> StateTransitionRecord:
+    return StateTransitionRecord(
+        transition_id=str(transition.transition_id),
+        run_id=str(transition.run.run_id),
+        entity_type=transition.entity_type.value,
+        entity_id=transition.entity_id,
+        from_state=transition.from_state,
+        to_state=transition.to_state,
+        cause_type=transition.cause_type,
+        cause_id=transition.cause_id,
+        occurred_at=transition.occurred_at,
+    )
+
+
+def state_transition_from_record(
+    record: StateTransitionRecord,
+    run: RunIdentity,
+) -> StateTransition:
+    return StateTransition(
+        transition_id=StateTransitionId(record.transition_id),
+        entity_type=TransitionEntityType(record.entity_type),
+        entity_id=record.entity_id,
+        from_state=record.from_state,
+        to_state=record.to_state,
+        cause_type=record.cause_type,
+        cause_id=record.cause_id,
+        occurred_at=record.occurred_at,
+        run=run,
+    )

--- a/signalforge/persistence/models.py
+++ b/signalforge/persistence/models.py
@@ -420,9 +420,7 @@ class ExitRecord(Base):
     realised_pnl: Mapped[Decimal] = mapped_column(
         Numeric(PRICE_PRECISION, PRICE_SCALE), nullable=False
     )
-    realised_r: Mapped[Decimal] = mapped_column(
-        Numeric(PRICE_PRECISION, PRICE_SCALE), nullable=False
-    )
+    realised_r: Mapped[Decimal] = mapped_column(Numeric(), nullable=False)
 
 
 class StateTransitionRecord(Base):

--- a/signalforge/runtime/position_manager.py
+++ b/signalforge/runtime/position_manager.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 
 from signalforge.domain.execution import ExecutionMode, Fill
 from signalforge.domain.exits import Exit, ExitReason
+from signalforge.domain.identity import canonical_decimal, canonical_timestamp
 from signalforge.domain.ids import FillId, TradeId, deterministic_id
 from signalforge.domain.instruments import TickSizeSchedule
 from signalforge.domain.market import MarketEvent
@@ -117,8 +118,8 @@ class PositionManager:
             str(trade.run.run_id),
             str(trade.trade_id),
             "exit",
-            event.exchange_timestamp.isoformat(),
-            str(event.price.value),
+            canonical_timestamp(event.exchange_timestamp),
+            canonical_decimal(event.price.value),
             reason.value,
         )
         exit_fact = Exit.create(

--- a/tests/integration/persistence/test_migrations.py
+++ b/tests/integration/persistence/test_migrations.py
@@ -48,7 +48,6 @@ def test_orm_metadata_declares_exact_canonical_table_set() -> None:
 
 def test_alembic_head_creates_canonical_runtime_schema(postgres_engine: Engine) -> None:
     inspector = sa.inspect(postgres_engine)
-
     assert EXPECTED_TABLES <= set(inspector.get_table_names())
 
     signal_pk = inspector.get_pk_constraint("signals")
@@ -68,6 +67,12 @@ def test_alembic_head_creates_canonical_runtime_schema(postgres_engine: Engine) 
     assert signal_close_type.precision == PRICE_PRECISION
     assert signal_close_type.scale == PRICE_SCALE
 
+    exit_columns = {column["name"]: column for column in inspector.get_columns("exits")}
+    realised_r_type = exit_columns["realised_r"]["type"]
+    assert isinstance(realised_r_type, sa.Numeric)
+    assert realised_r_type.precision is None
+    assert realised_r_type.scale is None
+
     created_at_type = signal_columns["created_at"]["type"]
     assert isinstance(created_at_type, sa.DateTime)
     assert created_at_type.timezone is True
@@ -75,12 +80,10 @@ def test_alembic_head_creates_canonical_runtime_schema(postgres_engine: Engine) 
 
 def test_schema_enforces_core_lifecycle_constraints(postgres_engine: Engine) -> None:
     inspector = sa.inspect(postgres_engine)
-
     trade_checks = {constraint["name"] for constraint in inspector.get_check_constraints("trades")}
     armed_checks = {
         constraint["name"] for constraint in inspector.get_check_constraints("armed_setups")
     }
-
     assert "ck_trade_close_metadata" in trade_checks
     assert "ck_trade_risk_positive" in trade_checks
     assert "ck_armed_terminal_metadata" in armed_checks
@@ -89,9 +92,7 @@ def test_schema_enforces_core_lifecycle_constraints(postgres_engine: Engine) -> 
 
 def test_initial_migration_is_reversible_and_reproducible(postgres_engine: Engine) -> None:
     config = Config("alembic.ini")
-
     command.downgrade(config, "base")
     assert not (EXPECTED_TABLES & set(sa.inspect(postgres_engine).get_table_names()))
-
     command.upgrade(config, "head")
     assert EXPECTED_TABLES <= set(sa.inspect(postgres_engine).get_table_names())

--- a/tests/integration/persistence/test_realised_r_precision.py
+++ b/tests/integration/persistence/test_realised_r_precision.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from signalforge.persistence.models import (
+    EntryIntentRecord,
+    ExitRecord,
+    FillRecord,
+    PositionRecord,
+    RunRecord,
+    SignalRecord,
+    StrategyConfigRecord,
+    TradeRecord,
+    TriggerEventRecord,
+)
+
+
+@pytest.fixture(scope="module")
+def postgres_engine() -> Iterator[Engine]:
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url is None:
+        pytest.skip("DATABASE_URL is required for realised_r precision integration tests")
+
+    engine = sa.create_engine(database_url)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def test_realised_r_uses_unconstrained_numeric(postgres_engine: Engine) -> None:
+    column = {item["name"]: item for item in sa.inspect(postgres_engine).get_columns("exits")}[
+        "realised_r"
+    ]
+    numeric = column["type"]
+
+    assert isinstance(numeric, sa.Numeric)
+    assert numeric.precision is None
+    assert numeric.scale is None
+
+
+def test_high_precision_realised_r_round_trips_exactly(postgres_engine: Engine) -> None:
+    at = datetime(2026, 9, 1, 10, 0, tzinfo=UTC)
+    realised_r = Decimal("1.1234567890123456789012345678901234567890123456789012345")
+
+    connection = postgres_engine.connect()
+    transaction = connection.begin()
+    try:
+        connection.execute(
+            StrategyConfigRecord.__table__.insert(),
+            {
+                "config_id": "precision-config",
+                "strategy_id": "intraday_momentum_v1",
+                "strategy_version": "1.0.0",
+                "config_hash": "precision-hash",
+            },
+        )
+        connection.execute(
+            RunRecord.__table__.insert(),
+            {
+                "run_id": "precision-run",
+                "config_id": "precision-config",
+                "engine_calculation_version": "engine-v1",
+            },
+        )
+        connection.execute(
+            SignalRecord.__table__.insert(),
+            {
+                "signal_id": "precision-signal",
+                "run_id": "precision-run",
+                "instrument_id": "NSE:TEST",
+                "interval_start": at,
+                "interval_end": at.replace(minute=5),
+                "signal_close": Decimal("101"),
+                "signal_low": Decimal("100"),
+                "created_at": at.replace(minute=5),
+            },
+        )
+        connection.execute(
+            TriggerEventRecord.__table__.insert(),
+            {
+                "trigger_event_id": "precision-trigger",
+                "signal_id": "precision-signal",
+                "run_id": "precision-run",
+                "instrument_id": "NSE:TEST",
+                "reference_price": Decimal("101.1"),
+                "observed_price": Decimal("101.2"),
+                "observed_at": at.replace(minute=6),
+            },
+        )
+        connection.execute(
+            EntryIntentRecord.__table__.insert(),
+            {
+                "entry_intent_id": "precision-intent",
+                "trigger_event_id": "precision-trigger",
+                "signal_id": "precision-signal",
+                "run_id": "precision-run",
+                "instrument_id": "NSE:TEST",
+                "reference_price": Decimal("101.1"),
+                "quantity": 10,
+                "execution_mode": "paper",
+                "created_at": at.replace(minute=6),
+            },
+        )
+        connection.execute(
+            FillRecord.__table__.insert(),
+            {
+                "fill_id": "precision-fill",
+                "entry_intent_id": "precision-intent",
+                "trigger_event_id": "precision-trigger",
+                "signal_id": "precision-signal",
+                "run_id": "precision-run",
+                "instrument_id": "NSE:TEST",
+                "reference_price": Decimal("101.1"),
+                "fill_price": Decimal("101.2"),
+                "quantity": 10,
+                "execution_mode": "paper",
+                "filled_at": at.replace(minute=6),
+            },
+        )
+        connection.execute(
+            TradeRecord.__table__.insert(),
+            {
+                "trade_id": "precision-trade",
+                "entry_fill_id": "precision-fill",
+                "signal_id": "precision-signal",
+                "run_id": "precision-run",
+                "instrument_id": "NSE:TEST",
+                "entry_price": Decimal("101.2"),
+                "stop_price": Decimal("100"),
+                "raw_target_price": Decimal("103"),
+                "tradable_target_price": Decimal("103"),
+                "risk_per_share": Decimal("1.2"),
+                "quantity": 10,
+                "opened_at": at.replace(minute=6),
+                "state": "open",
+                "closed_at": None,
+                "exit_id": None,
+            },
+        )
+        connection.execute(
+            PositionRecord.__table__.insert(),
+            {
+                "position_id": "precision-position",
+                "trade_id": "precision-trade",
+                "run_id": "precision-run",
+                "instrument_id": "NSE:TEST",
+                "quantity": 10,
+                "average_entry_price": Decimal("101.2"),
+                "opened_at": at.replace(minute=6),
+                "state": "open",
+                "closed_at": None,
+            },
+        )
+        connection.execute(
+            ExitRecord.__table__.insert(),
+            {
+                "exit_id": "precision-exit",
+                "exit_fill_id": "precision-exit-fill",
+                "trade_id": "precision-trade",
+                "position_id": "precision-position",
+                "run_id": "precision-run",
+                "instrument_id": "NSE:TEST",
+                "reason": "target",
+                "reference_price": Decimal("103"),
+                "fill_price": Decimal("103.1"),
+                "quantity": 10,
+                "execution_mode": "paper",
+                "exited_at": at.replace(minute=10),
+                "realised_pnl": Decimal("19"),
+                "realised_r": realised_r,
+            },
+        )
+
+        stored = connection.scalar(
+            sa.select(ExitRecord.realised_r).where(ExitRecord.exit_id == "precision-exit")
+        )
+        assert stored == realised_r
+        assert stored.as_tuple() == realised_r.as_tuple()
+    finally:
+        transaction.rollback()
+        connection.close()

--- a/tests/unit/domain/test_identity_canonical.py
+++ b/tests/unit/domain/test_identity_canonical.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from decimal import Decimal
+
+from signalforge.domain.execution import TriggerEvent
+from signalforge.domain.identity import canonical_decimal, canonical_timestamp
+from signalforge.domain.ids import ConfigId, InstrumentId, RunId, SignalId
+from signalforge.domain.money import Price
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        RunId("run"), StrategyIdentity("strategy", "1"), ConfigId("config"), "hash", "engine"
+    )
+
+
+def test_canonical_timestamp_uses_the_instant_not_its_offset() -> None:
+    first = datetime.fromisoformat("2026-08-31T10:00:00+05:30")
+    second = datetime.fromisoformat("2026-08-31T04:30:00+00:00")
+    assert canonical_timestamp(first) == canonical_timestamp(second)
+    assert canonical_decimal(Decimal("0")) == canonical_decimal(Decimal("-0.000")) == "0"
+    precise = Decimal("1.1234567890123456789012345678901234567890123456789012345")
+    assert canonical_decimal(precise) == format(precise, "f")
+
+
+def test_canonical_decimal_removes_only_insignificant_zeros() -> None:
+    assert canonical_decimal(Decimal("156.5")) == canonical_decimal(Decimal("156.5000"))
+    assert canonical_decimal(Decimal("1.519480519480519480519480519")) == (
+        "1.519480519480519480519480519"
+    )
+
+
+def test_trigger_identity_ignores_timestamp_and_decimal_representation() -> None:
+    values = {
+        "signal_id": SignalId("signal"),
+        "instrument_id": InstrumentId("NSE:X"),
+        "reference_price": Price(Decimal("10")),
+        "run": _run(),
+    }
+    first = TriggerEvent.create(
+        observed_price=Price(Decimal("156.5")),
+        observed_at=datetime.fromisoformat("2026-08-31T10:00:00+05:30"),
+        **values,
+    )
+    second = TriggerEvent.create(
+        observed_price=Price(Decimal("156.5000")),
+        observed_at=datetime.fromisoformat("2026-08-31T04:30:00+00:00"),
+        **values,
+    )
+    assert first.trigger_event_id == second.trigger_event_id

--- a/tests/unit/domain/test_identity_domain.py
+++ b/tests/unit/domain/test_identity_domain.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from signalforge.domain.execution import ExecutionMode, Fill, TriggerEvent
+from signalforge.domain.ids import (
+    ConfigId,
+    EntryIntentId,
+    FillId,
+    InstrumentId,
+    RunId,
+    SignalId,
+    TriggerEventId,
+)
+from signalforge.domain.instruments import TickSizeRule, TickSizeSchedule
+from signalforge.domain.market import MarketEvent
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.positions import Position
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.time import IST, CandleInterval
+from signalforge.domain.trades import Trade
+from signalforge.runtime.position_manager import PositionManager
+
+INSTRUMENT = InstrumentId("NSE:TEST")
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-canonical"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-canonical"),
+        config_hash="hash-canonical",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def test_signal_identity_canonicalizes_equivalent_interval_instants() -> None:
+    ist_start = datetime(2026, 8, 31, 10, 0, tzinfo=IST)
+    utc_start = datetime(2026, 8, 31, 4, 30, tzinfo=UTC)
+
+    def create(start: datetime) -> Signal:
+        interval = CandleInterval.five_minutes(start)
+        return Signal.create(
+            instrument_id=INSTRUMENT,
+            interval=interval,
+            signal_close=Price(Decimal("156.5")),
+            signal_low=Price(Decimal("155")),
+            run=_run(),
+            created_at=interval.end,
+        )
+
+    first = create(ist_start)
+    timezone_variant = create(utc_start)
+    repeated = create(ist_start)
+    assert {first.signal_id, timezone_variant.signal_id, repeated.signal_id} == {first.signal_id}
+
+
+def test_trigger_identity_canonicalizes_timestamp_and_decimal_components() -> None:
+    common = {
+        "signal_id": SignalId("signal-canonical"),
+        "instrument_id": INSTRUMENT,
+        "reference_price": Price(Decimal("156")),
+        "run": _run(),
+    }
+    first = TriggerEvent.create(
+        observed_price=Price(Decimal("156.5")),
+        observed_at=datetime(2026, 8, 31, 10, 0, tzinfo=IST),
+        **common,
+    )
+    timestamp_variant = TriggerEvent.create(
+        observed_price=Price(Decimal("156.5")),
+        observed_at=datetime(2026, 8, 31, 4, 30, tzinfo=UTC),
+        **common,
+    )
+    decimal_variant = TriggerEvent.create(
+        observed_price=Price(Decimal("156.5000")),
+        observed_at=datetime(2026, 8, 31, 10, 0, tzinfo=IST),
+        **common,
+    )
+
+    repeated = TriggerEvent.create(
+        observed_price=Price(Decimal("156.5")),
+        observed_at=datetime(2026, 8, 31, 10, 0, tzinfo=IST),
+        **common,
+    )
+
+    assert {
+        first.trigger_event_id,
+        timestamp_variant.trigger_event_id,
+        decimal_variant.trigger_event_id,
+        repeated.trigger_event_id,
+    } == {first.trigger_event_id}
+
+
+def test_fill_identity_canonicalizes_timestamp_and_decimal_components() -> None:
+    common = {
+        "entry_intent_id": EntryIntentId("intent-canonical"),
+        "trigger_event_id": TriggerEvent.create(
+            signal_id=SignalId("signal-canonical"),
+            instrument_id=INSTRUMENT,
+            reference_price=Price(Decimal("156")),
+            observed_price=Price(Decimal("156.5")),
+            observed_at=datetime(2026, 8, 31, 10, 0, tzinfo=IST),
+            run=_run(),
+        ).trigger_event_id,
+        "signal_id": SignalId("signal-canonical"),
+        "instrument_id": INSTRUMENT,
+        "reference_price": Price(Decimal("156")),
+        "quantity": Quantity(10),
+        "execution_mode": ExecutionMode.PAPER,
+        "run": _run(),
+    }
+    first = Fill.create(
+        fill_price=Price(Decimal("156.5")),
+        filled_at=datetime(2026, 8, 31, 10, 0, tzinfo=IST),
+        **common,
+    )
+    timestamp_variant = Fill.create(
+        fill_price=Price(Decimal("156.5")),
+        filled_at=datetime(2026, 8, 31, 4, 30, tzinfo=UTC),
+        **common,
+    )
+    decimal_variant = Fill.create(
+        fill_price=Price(Decimal("156.5000")),
+        filled_at=datetime(2026, 8, 31, 10, 0, tzinfo=IST),
+        **common,
+    )
+
+    repeated = Fill.create(
+        fill_price=Price(Decimal("156.5")),
+        filled_at=datetime(2026, 8, 31, 10, 0, tzinfo=IST),
+        **common,
+    )
+
+    assert {
+        first.fill_id,
+        timestamp_variant.fill_id,
+        decimal_variant.fill_id,
+        repeated.fill_id,
+    } == {first.fill_id}
+
+
+def _open_position() -> tuple[PositionManager, Trade, Position]:
+    end = datetime(2026, 8, 31, 10, 0, tzinfo=IST)
+    signal = Signal.create(
+        instrument_id=INSTRUMENT,
+        interval=CandleInterval(start=end - timedelta(minutes=5), end=end),
+        signal_close=Price(Decimal("101")),
+        signal_low=Price(Decimal("100")),
+        run=_run(),
+        created_at=end,
+    )
+    fill = Fill.create(
+        entry_intent_id=EntryIntentId("intent-exit-canonical"),
+        trigger_event_id=TriggerEvent.create(
+            signal_id=signal.signal_id,
+            instrument_id=INSTRUMENT,
+            reference_price=Price(Decimal("101")),
+            observed_price=Price(Decimal("101.1")),
+            observed_at=end + timedelta(minutes=1),
+            run=_run(),
+        ).trigger_event_id,
+        signal_id=signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=Price(Decimal("101")),
+        fill_price=Price(Decimal("101.1")),
+        quantity=Quantity(10),
+        execution_mode=ExecutionMode.PAPER,
+        filled_at=end + timedelta(minutes=1),
+        run=_run(),
+    )
+    schedule = TickSizeSchedule(
+        instrument_id=INSTRUMENT,
+        rules=(TickSizeRule(Price(Decimal("0.05")), date(2026, 1, 1)),),
+    )
+    manager = PositionManager(tick_schedule=schedule)
+    opened = manager.open_from_fill(fill, signal)
+    assert opened.trade is not None and opened.position is not None
+    return manager, opened.trade, opened.position
+
+
+def test_exit_fill_identity_canonicalizes_timestamp_and_decimal_components() -> None:
+    def exit_fill_id(at: datetime, price: str) -> FillId:
+        manager, trade, position = _open_position()
+        event = MarketEvent(
+            instrument_id=INSTRUMENT,
+            exchange_timestamp=at,
+            received_timestamp=at,
+            price=Price(Decimal(price)),
+            quantity=1,
+            source="canonical-test",
+        )
+        result = manager.process_market_event(trade, position, event)
+        assert result is not None
+        return result.exit_fill_id
+
+    first = exit_fill_id(datetime(2026, 8, 31, 10, 5, tzinfo=IST), "99.5")
+    timezone_variant = exit_fill_id(datetime(2026, 8, 31, 4, 35, tzinfo=UTC), "99.5")
+    decimal_variant = exit_fill_id(datetime(2026, 8, 31, 10, 5, tzinfo=IST), "99.5000")
+    repeated = exit_fill_id(datetime(2026, 8, 31, 10, 5, tzinfo=IST), "99.5")
+
+    assert {first, timezone_variant, decimal_variant, repeated} == {first}
+
+
+@pytest.mark.parametrize("zero", ["0", "-0.000"])
+def test_signed_zero_is_rejected_by_positive_price_domain_paths(zero: str) -> None:
+    at = datetime(2026, 8, 31, 10, 0, tzinfo=IST)
+    with pytest.raises(ValueError, match="strictly positive"):
+        TriggerEvent.create(
+            signal_id=SignalId("signal-zero"),
+            instrument_id=INSTRUMENT,
+            reference_price=Price(Decimal("1")),
+            observed_price=Price(Decimal(zero)),
+            observed_at=at,
+            run=_run(),
+        )
+    with pytest.raises(ValueError, match="strictly positive"):
+        Fill.create(
+            entry_intent_id=EntryIntentId("intent-zero"),
+            trigger_event_id=TriggerEventId("trigger-zero"),
+            signal_id=SignalId("signal-zero"),
+            instrument_id=INSTRUMENT,
+            reference_price=Price(Decimal("1")),
+            fill_price=Price(Decimal(zero)),
+            quantity=Quantity(1),
+            execution_mode=ExecutionMode.PAPER,
+            filled_at=at,
+            run=_run(),
+        )
+    with pytest.raises(ValueError, match="strictly positive"):
+        MarketEvent(
+            instrument_id=INSTRUMENT,
+            exchange_timestamp=at,
+            received_timestamp=at,
+            price=Price(Decimal(zero)),
+            quantity=1,
+            source="canonical-test",
+        )

--- a/tests/unit/persistence/test_contracts.py
+++ b/tests/unit/persistence/test_contracts.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import inspect
+
+from signalforge.persistence import contracts
+
+EXPECTED_CONTRACTS = {
+    "RunProvenanceRepository",
+    "StrategyEvaluationRepository",
+    "SignalRepository",
+    "ArmedSetupRepository",
+    "TriggerEventRepository",
+    "EntryIntentRepository",
+    "FillRepository",
+    "TradeRepository",
+    "PositionRepository",
+    "ExitRepository",
+    "StateTransitionRepository",
+}
+
+
+def test_repository_contract_inventory_is_complete_and_sql_free() -> None:
+    assert EXPECTED_CONTRACTS <= set(vars(contracts))
+    source = inspect.getsource(contracts)
+    assert "sqlalchemy" not in source.lower()
+    assert "postgresql" not in source.lower()
+    assert "list_all" not in source
+    assert "CheckpointRepository" not in source

--- a/tests/unit/persistence/test_mappers.py
+++ b/tests/unit/persistence/test_mappers.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from signalforge.domain.armed import ArmedSetup
+from signalforge.domain.audit import StateTransition, TransitionEntityType
+from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, TriggerEvent
+from signalforge.domain.exits import Exit, ExitReason
+from signalforge.domain.ids import ConfigId, InstrumentId, RunId
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.positions import Position
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.strategy import (
+    DecisionReason,
+    MomentumResult,
+    SetupResult,
+    StrategyEvaluation,
+    TrendResult,
+)
+from signalforge.domain.time import IST, CandleInterval
+from signalforge.domain.trades import Trade
+from signalforge.persistence.mappers import (
+    armed_setup_from_record,
+    armed_setup_record_from_domain,
+    entry_intent_from_record,
+    entry_intent_record_from_domain,
+    exit_from_record,
+    exit_record_from_domain,
+    fill_from_record,
+    fill_record_from_domain,
+    position_from_record,
+    position_record_from_domain,
+    run_identity_from_records,
+    run_record_from_domain,
+    signal_from_record,
+    signal_record_from_domain,
+    state_transition_from_record,
+    state_transition_record_from_domain,
+    strategy_config_record_from_domain,
+    strategy_evaluation_from_record,
+    strategy_evaluation_record_from_domain,
+    trade_from_record,
+    trade_record_from_domain,
+    trigger_event_from_record,
+    trigger_event_record_from_domain,
+)
+
+INSTRUMENT = InstrumentId("NSE:TEST")
+AT = datetime(2026, 8, 31, 10, 0, tzinfo=IST)
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("run-map"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("config-map"),
+        config_hash="hash-map",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def _record_values(record: object) -> dict[str, object]:
+    table = type(record).__table__
+    return {column.name: getattr(record, column.name) for column in table.columns}
+
+
+def test_provenance_and_evaluation_mappers_round_trip() -> None:
+    run = _run()
+    assert (
+        run_identity_from_records(
+            run_record_from_domain(run), strategy_config_record_from_domain(run)
+        )
+        == run
+    )
+
+    evaluation = StrategyEvaluation(
+        instrument_id=INSTRUMENT,
+        interval=CandleInterval.five_minutes(AT),
+        trend=TrendResult(True),
+        momentum=MomentumResult(True, True, True, None),
+        setup=SetupResult(True),
+        qualified=True,
+        actionable=True,
+        reasons=(DecisionReason.QUALIFIED, DecisionReason.ACTIONABLE),
+    )
+    record = strategy_evaluation_record_from_domain(run.run_id, evaluation)
+    restored = strategy_evaluation_from_record(record)
+    assert _record_values(strategy_evaluation_record_from_domain(run.run_id, restored)) == (
+        _record_values(record)
+    )
+
+
+def test_business_fact_and_current_state_mappers_round_trip() -> None:
+    run = _run()
+    interval = CandleInterval.five_minutes(AT)
+    signal = Signal.create(
+        instrument_id=INSTRUMENT,
+        interval=interval,
+        signal_close=Price(Decimal("101.00")),
+        signal_low=Price(Decimal("100.00")),
+        run=run,
+        created_at=interval.end,
+    )
+    signal_record = signal_record_from_domain(signal)
+    restored_signal = signal_from_record(signal_record, run)
+    assert _record_values(signal_record_from_domain(restored_signal)) == _record_values(
+        signal_record
+    )
+
+    setup = ArmedSetup(
+        signal_id=signal.signal_id,
+        raw_trigger=Price(Decimal("101.101")),
+        tradable_trigger=Price(Decimal("101.15")),
+        signal_low=signal.signal_low,
+        armed_at=interval.end,
+        valid_until=interval.end + timedelta(minutes=5),
+    )
+    setup_record = armed_setup_record_from_domain(run.run_id, setup)
+    restored_setup = armed_setup_from_record(setup_record)
+    assert _record_values(armed_setup_record_from_domain(run.run_id, restored_setup)) == (
+        _record_values(setup_record)
+    )
+
+    trigger = TriggerEvent.create(
+        signal_id=signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=setup.tradable_trigger,
+        observed_price=Price(Decimal("101.20")),
+        observed_at=interval.end + timedelta(minutes=1),
+        run=run,
+    )
+    trigger_record = trigger_event_record_from_domain(trigger)
+    restored_trigger = trigger_event_from_record(trigger_record, run)
+    assert _record_values(trigger_event_record_from_domain(restored_trigger)) == _record_values(
+        trigger_record
+    )
+
+    intent = EntryIntent.create(
+        trigger_event_id=trigger.trigger_event_id,
+        signal_id=signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=trigger.reference_price,
+        quantity=Quantity(10),
+        execution_mode=ExecutionMode.PAPER,
+        created_at=trigger.observed_at,
+        run=run,
+    )
+    intent_record = entry_intent_record_from_domain(intent)
+    restored_intent = entry_intent_from_record(intent_record, run)
+    assert _record_values(entry_intent_record_from_domain(restored_intent)) == _record_values(
+        intent_record
+    )
+
+    fill = Fill.create(
+        entry_intent_id=intent.entry_intent_id,
+        trigger_event_id=trigger.trigger_event_id,
+        signal_id=signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=trigger.reference_price,
+        fill_price=Price(Decimal("101.20")),
+        quantity=intent.quantity,
+        execution_mode=intent.execution_mode,
+        filled_at=trigger.observed_at,
+        run=run,
+    )
+    fill_record = fill_record_from_domain(fill)
+    restored_fill = fill_from_record(fill_record, run)
+    assert _record_values(fill_record_from_domain(restored_fill)) == _record_values(fill_record)
+
+    trade = Trade.open_from_fill(
+        entry_fill=fill,
+        stop_price=signal.signal_low,
+        target_tick_size=Price(Decimal("0.05")),
+    )
+    position = Position.open_from_trade(trade=trade)
+    exit_fact = Exit.create(
+        trade=trade,
+        position=position,
+        exit_fill_id=fill.fill_id,
+        reason=ExitReason.TARGET,
+        reference_price=trade.tradable_target_price,
+        fill_price=Price(Decimal("103.05")),
+        quantity=trade.quantity,
+        execution_mode=ExecutionMode.PAPER,
+        exited_at=trigger.observed_at + timedelta(minutes=5),
+    )
+
+    exit_record = exit_record_from_domain(exit_fact)
+    restored_exit = exit_from_record(exit_record, run)
+    assert _record_values(exit_record_from_domain(restored_exit)) == _record_values(exit_record)
+
+    trade.close(exit_id=exit_fact.exit_id, at=exit_fact.exited_at)
+    position.close(at=exit_fact.exited_at)
+    trade_record = trade_record_from_domain(trade)
+    position_record = position_record_from_domain(position)
+    assert _record_values(trade_record_from_domain(trade_from_record(trade_record, run))) == (
+        _record_values(trade_record)
+    )
+    assert _record_values(
+        position_record_from_domain(position_from_record(position_record, run))
+    ) == _record_values(position_record)
+
+    transition = StateTransition.create(
+        entity_type=TransitionEntityType.TRADE,
+        entity_id=str(trade.trade_id),
+        from_state="open",
+        to_state="closed",
+        cause_type="exit",
+        cause_id=str(exit_fact.exit_id),
+        occurred_at=exit_fact.exited_at,
+        run=run,
+    )
+    transition_record = state_transition_record_from_domain(transition)
+    restored_transition = state_transition_from_record(transition_record, run)
+    assert _record_values(state_transition_record_from_domain(restored_transition)) == (
+        _record_values(transition_record)
+    )


### PR DESCRIPTION
## Summary

Implements SF-045A as the persistence-foundation issue under M6.

- establishes 11 narrow SQL-free persistence repository contracts
- adds explicit domain/ORM mappers for SF-045-owned persistence concepts
- adds a compact persistence error taxonomy
- canonicalizes deterministic identity inputs for timezone-equivalent timestamps and numerically equivalent Decimals, including signed zero
- applies canonical identity handling to Signal, TriggerEvent, Fill, and generated exit-fill identities
- changes `exits.realised_r` from bounded `NUMERIC(38,18)` to unconstrained PostgreSQL `NUMERIC`
- adds a forward Alembic migration without rewriting merged SF-044 history
- proves a 55-fractional-digit realised-R value round-trips exactly through PostgreSQL
- documents deterministic-ID compatibility implications

## Validation

Local PostgreSQL-enabled validation completed successfully:

- focused identity tests: 9 passed
- contract/mapper tests: 3 passed
- migration tests: 4 passed
- persistence integration tests: 6 passed
- explicit Alembic downgrade/upgrade cycle: passed
- full suite: 391 passed
- Ruff: passed
- strict mypy: passed across 47 source files
- `git diff --check`: clean

Normal pytest capture on the host reproduced an environment-specific temporary-file failure before collection; `pytest -s` completed all 391 tests successfully.

## Scope discipline

No implementation from SF-045B, SF-045C, SF-046, or SF-047 is included. No PostgreSQL repository adapters, transaction orchestration, Unit of Work, checkpoint persistence, recovery loaders, broker/OpenAlgo integration, or strategy changes are introduced.

Closes #127
Parent: #101