### PR TITLE
SF-045B — PostgreSQL adapters for immutable facts and provenance

### DIFF
--- a/signalforge/persistence/__init__.py
+++ b/signalforge/persistence/__init__.py
@@ -1,5 +1,25 @@
 """PostgreSQL persistence metadata and infrastructure boundaries."""
 
 from signalforge.persistence.models import Base
+from signalforge.persistence.repositories import (
+    PostgresEntryIntentRepository,
+    PostgresExitRepository,
+    PostgresFillRepository,
+    PostgresRunProvenanceRepository,
+    PostgresSignalRepository,
+    PostgresStateTransitionRepository,
+    PostgresStrategyEvaluationRepository,
+    PostgresTriggerEventRepository,
+)
 
-__all__ = ["Base"]
+__all__ = [
+    "Base",
+    "PostgresEntryIntentRepository",
+    "PostgresExitRepository",
+    "PostgresFillRepository",
+    "PostgresRunProvenanceRepository",
+    "PostgresSignalRepository",
+    "PostgresStateTransitionRepository",
+    "PostgresStrategyEvaluationRepository",
+    "PostgresTriggerEventRepository",
+]

--- a/signalforge/persistence/repositories.py
+++ b/signalforge/persistence/repositories.py
@@ -1,0 +1,489 @@
+"""Caller-session PostgreSQL adapters for immutable facts and provenance.
+
+The adapters execute writes immediately but leave commit and rollback ownership with
+their caller. PostgreSQL ``ON CONFLICT DO NOTHING`` keeps expected duplicate races from
+poisoning the caller's transaction; the persisted domain fact is then compared with the
+requested fact to distinguish an exact retry from contradictory identity reuse.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import cast
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.selectable import FromClause, TableClause
+
+from signalforge.domain.audit import StateTransition
+from signalforge.domain.execution import EntryIntent, Fill, TriggerEvent
+from signalforge.domain.exits import Exit
+from signalforge.domain.ids import (
+    EntryIntentId,
+    ExitId,
+    FillId,
+    InstrumentId,
+    RunId,
+    SignalId,
+    StateTransitionId,
+    TriggerEventId,
+)
+from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.strategy import StrategyEvaluation
+from signalforge.domain.time import CandleInterval
+from signalforge.persistence.errors import (
+    ContradictoryFactError,
+    PersistenceDependencyError,
+    PersistenceError,
+)
+from signalforge.persistence.mappers import (
+    entry_intent_from_record,
+    entry_intent_record_from_domain,
+    exit_from_record,
+    exit_record_from_domain,
+    fill_from_record,
+    fill_record_from_domain,
+    run_identity_from_records,
+    run_record_from_domain,
+    signal_from_record,
+    signal_record_from_domain,
+    state_transition_from_record,
+    state_transition_record_from_domain,
+    strategy_config_record_from_domain,
+    strategy_evaluation_from_record,
+    strategy_evaluation_record_from_domain,
+    trigger_event_from_record,
+    trigger_event_record_from_domain,
+)
+from signalforge.persistence.models import (
+    EntryIntentRecord,
+    ExitRecord,
+    FillRecord,
+    PositionRecord,
+    RunRecord,
+    SignalRecord,
+    StateTransitionRecord,
+    StrategyConfigRecord,
+    StrategyEvaluationRecord,
+    TradeRecord,
+    TriggerEventRecord,
+)
+
+
+def _insert_ignoring_unique_conflicts(
+    session: Session,
+    table: FromClause,
+    record: object,
+) -> None:
+    values = {column.name: getattr(record, column.name) for column in table.columns}
+    session.execute(insert(cast(TableClause, table)).values(values).on_conflict_do_nothing())
+
+
+def _single_collision[RecordT](
+    records: Sequence[RecordT], *, fact_name: str
+) -> RecordT | None:
+    if len(records) > 1:
+        raise ContradictoryFactError(
+            f"{fact_name} primary and alternate identities resolve to different stored facts"
+        )
+    return records[0] if records else None
+
+
+def _append_immutable[FactT, RecordT](
+    *,
+    session: Session,
+    table: FromClause,
+    record: object,
+    requested: FactT,
+    find_existing: Callable[[], RecordT | None],
+    hydrate: Callable[[RecordT], FactT],
+    fact_name: str,
+) -> FactT:
+    existing = find_existing()
+    if existing is None:
+        _insert_ignoring_unique_conflicts(session, table, record)
+        existing = find_existing()
+    if existing is None:
+        raise PersistenceError(f"{fact_name} insert did not produce a persisted fact")
+    persisted = hydrate(existing)
+    if persisted != requested:
+        raise ContradictoryFactError(
+            f"stored {fact_name} contradicts requested immutable fact"
+        )
+    return persisted
+
+
+class _PostgresRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def _load_run(self, run_id: RunId | str) -> RunIdentity | None:
+        run = self._session.get(RunRecord, str(run_id))
+        if run is None:
+            return None
+        config = self._session.get(StrategyConfigRecord, run.config_id)
+        if config is None:
+            raise PersistenceDependencyError(
+                f"run {run.run_id!r} references missing config {run.config_id!r}"
+            )
+        return run_identity_from_records(run, config)
+
+    def _require_run(self, expected: RunIdentity) -> RunIdentity:
+        persisted = self._load_run(expected.run_id)
+        if persisted is None:
+            raise PersistenceDependencyError(
+                f"run provenance {expected.run_id!s} must be persisted first"
+            )
+        if persisted != expected:
+            raise ContradictoryFactError(
+                f"stored run provenance {expected.run_id!s} contradicts fact provenance"
+            )
+        return persisted
+
+    def _require_record[RecordT](
+        self, model: type[RecordT], identity: str, *, name: str
+    ) -> RecordT:
+        record = self._session.get(model, identity)
+        if record is None:
+            raise PersistenceDependencyError(f"{name} {identity!r} must be persisted first")
+        return record
+
+
+class PostgresRunProvenanceRepository(_PostgresRepository):
+    """Persist complete immutable config and run provenance using the caller's Session."""
+
+    def _find_config(self, candidate: StrategyConfigRecord) -> StrategyConfigRecord | None:
+        records = self._session.scalars(
+            sa.select(StrategyConfigRecord).where(
+                sa.or_(
+                    StrategyConfigRecord.config_id == candidate.config_id,
+                    sa.and_(
+                        StrategyConfigRecord.strategy_id == candidate.strategy_id,
+                        StrategyConfigRecord.strategy_version == candidate.strategy_version,
+                        StrategyConfigRecord.config_hash == candidate.config_hash,
+                    ),
+                )
+            )
+        ).all()
+        return _single_collision(records, fact_name="strategy config provenance")
+
+    @staticmethod
+    def _same_config(
+        stored: StrategyConfigRecord,
+        candidate: StrategyConfigRecord,
+    ) -> bool:
+        return (
+            stored.config_id,
+            stored.strategy_id,
+            stored.strategy_version,
+            stored.config_hash,
+        ) == (
+            candidate.config_id,
+            candidate.strategy_id,
+            candidate.strategy_version,
+            candidate.config_hash,
+        )
+
+    def add(self, run: RunIdentity) -> RunIdentity:
+        config_candidate = strategy_config_record_from_domain(run)
+        run_candidate = run_record_from_domain(run)
+        with self._session.begin_nested():
+            config = self._find_config(config_candidate)
+            if config is None:
+                _insert_ignoring_unique_conflicts(
+                    self._session,
+                    StrategyConfigRecord.__table__,
+                    config_candidate,
+                )
+                config = self._find_config(config_candidate)
+            if config is None:
+                raise PersistenceError("config provenance insert produced no persisted record")
+            if not self._same_config(config, config_candidate):
+                raise ContradictoryFactError(
+                    "stored strategy config contradicts requested immutable provenance"
+                )
+
+            stored_run = self._session.get(RunRecord, run_candidate.run_id)
+            if stored_run is None:
+                _insert_ignoring_unique_conflicts(
+                    self._session,
+                    RunRecord.__table__,
+                    run_candidate,
+                )
+                stored_run = self._session.get(RunRecord, run_candidate.run_id)
+            if stored_run is None:
+                raise PersistenceError("run provenance insert produced no persisted record")
+            persisted = run_identity_from_records(stored_run, config)
+            if persisted != run:
+                raise ContradictoryFactError(
+                    "stored run contradicts requested immutable provenance"
+                )
+        return persisted
+
+    def get(self, run_id: RunId) -> RunIdentity | None:
+        return self._load_run(run_id)
+
+
+class PostgresStrategyEvaluationRepository(_PostgresRepository):
+    def append(
+        self,
+        run_id: RunId,
+        evaluation: StrategyEvaluation,
+    ) -> StrategyEvaluation:
+        if self._load_run(run_id) is None:
+            raise PersistenceDependencyError(f"run provenance {run_id!s} must be persisted first")
+        candidate = strategy_evaluation_record_from_domain(run_id, evaluation)
+
+        def find() -> StrategyEvaluationRecord | None:
+            return self._session.get(
+                StrategyEvaluationRecord,
+                (
+                    str(run_id),
+                    str(evaluation.instrument_id),
+                    evaluation.interval.start,
+                    evaluation.interval.end,
+                ),
+            )
+
+        return _append_immutable(
+            session=self._session,
+            table=StrategyEvaluationRecord.__table__,
+            record=candidate,
+            requested=evaluation,
+            find_existing=find,
+            hydrate=strategy_evaluation_from_record,
+            fact_name="strategy evaluation",
+        )
+
+    def get(
+        self,
+        run_id: RunId,
+        instrument_id: InstrumentId,
+        interval: CandleInterval,
+    ) -> StrategyEvaluation | None:
+        record = self._session.get(
+            StrategyEvaluationRecord,
+            (str(run_id), str(instrument_id), interval.start, interval.end),
+        )
+        return None if record is None else strategy_evaluation_from_record(record)
+
+
+class PostgresSignalRepository(_PostgresRepository):
+    def _find(self, signal: Signal) -> SignalRecord | None:
+        records = self._session.scalars(
+            sa.select(SignalRecord).where(
+                sa.or_(
+                    SignalRecord.signal_id == str(signal.signal_id),
+                    sa.and_(
+                        SignalRecord.run_id == str(signal.run.run_id),
+                        SignalRecord.instrument_id == str(signal.instrument_id),
+                        SignalRecord.interval_start == signal.interval.start,
+                        SignalRecord.interval_end == signal.interval.end,
+                    ),
+                )
+            )
+        ).all()
+        return _single_collision(records, fact_name="signal")
+
+    def append(self, signal: Signal) -> Signal:
+        run = self._require_run(signal.run)
+        candidate = signal_record_from_domain(signal)
+        return _append_immutable(
+            session=self._session,
+            table=SignalRecord.__table__,
+            record=candidate,
+            requested=signal,
+            find_existing=lambda: self._find(signal),
+            hydrate=lambda record: signal_from_record(record, run),
+            fact_name="signal",
+        )
+
+    def get(self, signal_id: SignalId) -> Signal | None:
+        record = self._session.get(SignalRecord, str(signal_id))
+        if record is None:
+            return None
+        run = self._load_run(record.run_id)
+        if run is None:
+            raise PersistenceDependencyError("signal references missing run provenance")
+        return signal_from_record(record, run)
+
+
+class PostgresTriggerEventRepository(_PostgresRepository):
+    def append(self, event: TriggerEvent) -> TriggerEvent:
+        run = self._require_run(event.run)
+        self._require_record(SignalRecord, str(event.signal_id), name="signal")
+        candidate = trigger_event_record_from_domain(event)
+        return _append_immutable(
+            session=self._session,
+            table=TriggerEventRecord.__table__,
+            record=candidate,
+            requested=event,
+            find_existing=lambda: self._session.get(
+                TriggerEventRecord, str(event.trigger_event_id)
+            ),
+            hydrate=lambda record: trigger_event_from_record(record, run),
+            fact_name="trigger event",
+        )
+
+    def get(self, event_id: TriggerEventId) -> TriggerEvent | None:
+        record = self._session.get(TriggerEventRecord, str(event_id))
+        if record is None:
+            return None
+        run = self._load_run(record.run_id)
+        if run is None:
+            raise PersistenceDependencyError("trigger event references missing run provenance")
+        return trigger_event_from_record(record, run)
+
+
+class PostgresEntryIntentRepository(_PostgresRepository):
+    def _find(self, intent: EntryIntent) -> EntryIntentRecord | None:
+        records = self._session.scalars(
+            sa.select(EntryIntentRecord).where(
+                sa.or_(
+                    EntryIntentRecord.entry_intent_id == str(intent.entry_intent_id),
+                    EntryIntentRecord.trigger_event_id == str(intent.trigger_event_id),
+                )
+            )
+        ).all()
+        return _single_collision(records, fact_name="entry intent")
+
+    def append(self, intent: EntryIntent) -> EntryIntent:
+        run = self._require_run(intent.run)
+        self._require_record(
+            TriggerEventRecord,
+            str(intent.trigger_event_id),
+            name="trigger event",
+        )
+        self._require_record(SignalRecord, str(intent.signal_id), name="signal")
+        candidate = entry_intent_record_from_domain(intent)
+        return _append_immutable(
+            session=self._session,
+            table=EntryIntentRecord.__table__,
+            record=candidate,
+            requested=intent,
+            find_existing=lambda: self._find(intent),
+            hydrate=lambda record: entry_intent_from_record(record, run),
+            fact_name="entry intent",
+        )
+
+    def get(self, intent_id: EntryIntentId) -> EntryIntent | None:
+        record = self._session.get(EntryIntentRecord, str(intent_id))
+        if record is None:
+            return None
+        run = self._load_run(record.run_id)
+        if run is None:
+            raise PersistenceDependencyError("entry intent references missing run provenance")
+        return entry_intent_from_record(record, run)
+
+
+class PostgresFillRepository(_PostgresRepository):
+    def _find(self, fill: Fill) -> FillRecord | None:
+        records = self._session.scalars(
+            sa.select(FillRecord).where(
+                sa.or_(
+                    FillRecord.fill_id == str(fill.fill_id),
+                    FillRecord.entry_intent_id == str(fill.entry_intent_id),
+                )
+            )
+        ).all()
+        return _single_collision(records, fact_name="fill")
+
+    def append(self, fill: Fill) -> Fill:
+        run = self._require_run(fill.run)
+        self._require_record(
+            EntryIntentRecord,
+            str(fill.entry_intent_id),
+            name="entry intent",
+        )
+        self._require_record(
+            TriggerEventRecord,
+            str(fill.trigger_event_id),
+            name="trigger event",
+        )
+        self._require_record(SignalRecord, str(fill.signal_id), name="signal")
+        candidate = fill_record_from_domain(fill)
+        return _append_immutable(
+            session=self._session,
+            table=FillRecord.__table__,
+            record=candidate,
+            requested=fill,
+            find_existing=lambda: self._find(fill),
+            hydrate=lambda record: fill_from_record(record, run),
+            fact_name="fill",
+        )
+
+    def get(self, fill_id: FillId) -> Fill | None:
+        record = self._session.get(FillRecord, str(fill_id))
+        if record is None:
+            return None
+        run = self._load_run(record.run_id)
+        if run is None:
+            raise PersistenceDependencyError("fill references missing run provenance")
+        return fill_from_record(record, run)
+
+
+class PostgresExitRepository(_PostgresRepository):
+    def _find(self, exit_fact: Exit) -> ExitRecord | None:
+        records = self._session.scalars(
+            sa.select(ExitRecord).where(
+                sa.or_(
+                    ExitRecord.exit_id == str(exit_fact.exit_id),
+                    ExitRecord.exit_fill_id == str(exit_fact.exit_fill_id),
+                    ExitRecord.trade_id == str(exit_fact.trade_id),
+                    ExitRecord.position_id == str(exit_fact.position_id),
+                )
+            )
+        ).all()
+        return _single_collision(records, fact_name="exit")
+
+    def append(self, exit_fact: Exit) -> Exit:
+        run = self._require_run(exit_fact.run)
+        self._require_record(TradeRecord, str(exit_fact.trade_id), name="trade")
+        self._require_record(PositionRecord, str(exit_fact.position_id), name="position")
+        candidate = exit_record_from_domain(exit_fact)
+        return _append_immutable(
+            session=self._session,
+            table=ExitRecord.__table__,
+            record=candidate,
+            requested=exit_fact,
+            find_existing=lambda: self._find(exit_fact),
+            hydrate=lambda record: exit_from_record(record, run),
+            fact_name="exit",
+        )
+
+    def get(self, exit_id: ExitId) -> Exit | None:
+        record = self._session.get(ExitRecord, str(exit_id))
+        if record is None:
+            return None
+        run = self._load_run(record.run_id)
+        if run is None:
+            raise PersistenceDependencyError("exit references missing run provenance")
+        return exit_from_record(record, run)
+
+
+class PostgresStateTransitionRepository(_PostgresRepository):
+    def append(self, transition: StateTransition) -> StateTransition:
+        run = self._require_run(transition.run)
+        candidate = state_transition_record_from_domain(transition)
+        return _append_immutable(
+            session=self._session,
+            table=StateTransitionRecord.__table__,
+            record=candidate,
+            requested=transition,
+            find_existing=lambda: self._session.get(
+                StateTransitionRecord, str(transition.transition_id)
+            ),
+            hydrate=lambda record: state_transition_from_record(record, run),
+            fact_name="state transition",
+        )
+
+    def get(self, transition_id: StateTransitionId) -> StateTransition | None:
+        record = self._session.get(StateTransitionRecord, str(transition_id))
+        if record is None:
+            return None
+        run = self._load_run(record.run_id)
+        if run is None:
+            raise PersistenceDependencyError("state transition references missing run provenance")
+        return state_transition_from_record(record, run)

--- a/tests/integration/persistence/test_repository_adapters_postgres.py
+++ b/tests/integration/persistence/test_repository_adapters_postgres.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from signalforge.domain.audit import StateTransition, TransitionEntityType
+from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, TriggerEvent
+from signalforge.domain.exits import Exit, ExitReason
+from signalforge.domain.ids import ConfigId, FillId, InstrumentId, RunId
+from signalforge.domain.money import Price, Quantity
+from signalforge.domain.positions import Position
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.signals import Signal
+from signalforge.domain.strategy import (
+    DecisionReason,
+    MomentumResult,
+    SetupResult,
+    StrategyEvaluation,
+    TrendResult,
+)
+from signalforge.domain.time import IST, CandleInterval
+from signalforge.domain.trades import Trade
+from signalforge.persistence.errors import ContradictoryFactError
+from signalforge.persistence.mappers import (
+    position_record_from_domain,
+    trade_record_from_domain,
+)
+from signalforge.persistence.models import RunRecord, StrategyConfigRecord
+from signalforge.persistence.repositories import (
+    PostgresEntryIntentRepository,
+    PostgresExitRepository,
+    PostgresFillRepository,
+    PostgresRunProvenanceRepository,
+    PostgresSignalRepository,
+    PostgresStateTransitionRepository,
+    PostgresStrategyEvaluationRepository,
+    PostgresTriggerEventRepository,
+)
+
+AT = datetime(2026, 9, 1, 10, 0, tzinfo=IST)
+INSTRUMENT = InstrumentId("NSE:SF045B")
+
+
+@pytest.fixture(scope="module")
+def postgres_engine() -> Iterator[Engine]:
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url is None:
+        pytest.fail("DATABASE_URL is required for SF-045B PostgreSQL integration tests")
+    engine = sa.create_engine(database_url)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def session(postgres_engine: Engine) -> Iterator[Session]:
+    with Session(postgres_engine) as caller_session:
+        try:
+            yield caller_session
+        finally:
+            caller_session.rollback()
+
+
+@dataclass(frozen=True, slots=True)
+class Facts:
+    run: RunIdentity
+    evaluation: StrategyEvaluation
+    signal: Signal
+    trigger: TriggerEvent
+    intent: EntryIntent
+    fill: Fill
+    trade: Trade
+    position: Position
+    exit_fact: Exit
+    transition: StateTransition
+
+
+def facts(suffix: str = "base", *, at: datetime = AT) -> Facts:
+    run = RunIdentity(
+        run_id=RunId(f"sf045b-run-{suffix}"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId(f"sf045b-config-{suffix}"),
+        config_hash=f"sf045b-hash-{suffix}",
+        engine_calculation_version="engine-v1",
+    )
+    interval = CandleInterval.five_minutes(at)
+    evaluation = StrategyEvaluation(
+        instrument_id=INSTRUMENT,
+        interval=interval,
+        trend=TrendResult(True),
+        momentum=MomentumResult(True, True, True, None),
+        setup=SetupResult(True),
+        qualified=True,
+        actionable=True,
+        reasons=(DecisionReason.QUALIFIED, DecisionReason.ACTIONABLE),
+    )
+    signal = Signal.create(
+        instrument_id=INSTRUMENT,
+        interval=interval,
+        signal_close=Price(Decimal("101.00")),
+        signal_low=Price(Decimal("100.00")),
+        run=run,
+        created_at=interval.end,
+    )
+    trigger = TriggerEvent.create(
+        signal_id=signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=Price(Decimal("101.15")),
+        observed_price=Price(Decimal("101.20")),
+        observed_at=interval.end + timedelta(minutes=1),
+        run=run,
+    )
+    intent = EntryIntent.create(
+        trigger_event_id=trigger.trigger_event_id,
+        signal_id=signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=trigger.reference_price,
+        quantity=Quantity(10),
+        execution_mode=ExecutionMode.PAPER,
+        created_at=trigger.observed_at,
+        run=run,
+    )
+    fill = Fill.create(
+        entry_intent_id=intent.entry_intent_id,
+        trigger_event_id=trigger.trigger_event_id,
+        signal_id=signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=trigger.reference_price,
+        fill_price=Price(Decimal("101.20")),
+        quantity=intent.quantity,
+        execution_mode=intent.execution_mode,
+        filled_at=trigger.observed_at,
+        run=run,
+    )
+    trade = Trade.open_from_fill(
+        entry_fill=fill,
+        stop_price=signal.signal_low,
+        target_tick_size=Price(Decimal("0.05")),
+    )
+    position = Position.open_from_trade(trade=trade)
+    exit_fact = Exit.create(
+        trade=trade,
+        position=position,
+        exit_fill_id=FillId(f"sf045b-exit-fill-{suffix}"),
+        reason=ExitReason.TARGET,
+        reference_price=trade.tradable_target_price,
+        fill_price=Price(Decimal("103.123456789012345678")),
+        quantity=trade.quantity,
+        execution_mode=ExecutionMode.PAPER,
+        exited_at=fill.filled_at + timedelta(minutes=5),
+    )
+    transition = StateTransition.create(
+        entity_type=TransitionEntityType.TRADE,
+        entity_id=str(trade.trade_id),
+        from_state="open",
+        to_state="closed",
+        cause_type="exit",
+        cause_id=str(exit_fact.exit_id),
+        occurred_at=exit_fact.exited_at,
+        run=run,
+    )
+    return Facts(
+        run,
+        evaluation,
+        signal,
+        trigger,
+        intent,
+        fill,
+        trade,
+        position,
+        exit_fact,
+        transition,
+    )
+
+
+def persist_graph(session: Session, value: Facts) -> None:
+    assert PostgresRunProvenanceRepository(session).add(value.run) == value.run
+    assert (
+        PostgresStrategyEvaluationRepository(session).append(
+            value.run.run_id, value.evaluation
+        )
+        == value.evaluation
+    )
+    assert PostgresSignalRepository(session).append(value.signal) == value.signal
+    assert PostgresTriggerEventRepository(session).append(value.trigger) == value.trigger
+    assert PostgresEntryIntentRepository(session).append(value.intent) == value.intent
+    assert PostgresFillRepository(session).append(value.fill) == value.fill
+    session.add(trade_record_from_domain(value.trade))
+    session.flush()
+    session.add(position_record_from_domain(value.position))
+    session.flush()
+    assert PostgresExitRepository(session).append(value.exit_fact) == value.exit_fact
+    assert (
+        PostgresStateTransitionRepository(session).append(value.transition)
+        == value.transition
+    )
+
+
+def test_all_immutable_repositories_round_trip_and_retry_exactly(session: Session) -> None:
+    value = facts()
+    persist_graph(session, value)
+
+    provenance = PostgresRunProvenanceRepository(session)
+    evaluations = PostgresStrategyEvaluationRepository(session)
+    signals = PostgresSignalRepository(session)
+    triggers = PostgresTriggerEventRepository(session)
+    intents = PostgresEntryIntentRepository(session)
+    fills = PostgresFillRepository(session)
+    exits = PostgresExitRepository(session)
+    transitions = PostgresStateTransitionRepository(session)
+
+    assert provenance.add(value.run) == provenance.get(value.run.run_id) == value.run
+    assert evaluations.append(value.run.run_id, value.evaluation) == value.evaluation
+    assert (
+        evaluations.get(value.run.run_id, INSTRUMENT, value.evaluation.interval)
+        == value.evaluation
+    )
+    assert signals.append(value.signal) == signals.get(value.signal.signal_id) == value.signal
+    assert (
+        triggers.append(value.trigger)
+        == triggers.get(value.trigger.trigger_event_id)
+        == value.trigger
+    )
+    assert (
+        intents.append(value.intent)
+        == intents.get(value.intent.entry_intent_id)
+        == value.intent
+    )
+    assert fills.append(value.fill) == fills.get(value.fill.fill_id) == value.fill
+    assert (
+        exits.append(value.exit_fact)
+        == exits.get(value.exit_fact.exit_id)
+        == value.exit_fact
+    )
+    assert (
+        transitions.append(value.transition)
+        == transitions.get(value.transition.transition_id)
+        == value.transition
+    )
+    assert exits.get(value.exit_fact.exit_id).realised_r.as_tuple() == (
+        value.exit_fact.realised_r.as_tuple()
+    )
+    assert signals.get(value.signal.signal_id).created_at == value.signal.created_at
+
+
+def test_contradictory_reuse_is_typed_and_outer_transaction_remains_usable(
+    session: Session,
+) -> None:
+    value = facts("conflicts", at=AT + timedelta(hours=1))
+    persist_graph(session, value)
+
+    unqualified = StrategyEvaluation(
+        instrument_id=INSTRUMENT,
+        interval=value.evaluation.interval,
+        trend=TrendResult(False),
+        momentum=MomentumResult(True, True, True, False),
+        setup=SetupResult(True),
+        qualified=False,
+        actionable=False,
+        reasons=(DecisionReason.TREND_NOT_MET,),
+    )
+    contradictions: tuple[tuple[object, object], ...] = (
+        (
+            PostgresRunProvenanceRepository(session),
+            replace(value.run, engine_calculation_version="engine-v2"),
+        ),
+        (PostgresStrategyEvaluationRepository(session), unqualified),
+        (
+            PostgresSignalRepository(session),
+            replace(value.signal, signal_close=Price(Decimal("102.00"))),
+        ),
+        (
+            PostgresTriggerEventRepository(session),
+            replace(value.trigger, reference_price=Price(Decimal("101.10"))),
+        ),
+        (
+            PostgresEntryIntentRepository(session),
+            replace(value.intent, reference_price=Price(Decimal("101.10"))),
+        ),
+        (
+            PostgresFillRepository(session),
+            replace(value.fill, reference_price=Price(Decimal("101.10"))),
+        ),
+        (
+            PostgresExitRepository(session),
+            replace(value.exit_fact, reason=ExitReason.STOP),
+        ),
+        (
+            PostgresStateTransitionRepository(session),
+            replace(
+                value.transition,
+                run=replace(value.run, engine_calculation_version="engine-v2"),
+            ),
+        ),
+    )
+
+    for repository, contradictory in contradictions:
+        with pytest.raises(ContradictoryFactError):
+            if isinstance(repository, PostgresRunProvenanceRepository):
+                repository.add(contradictory)  # type: ignore[arg-type]
+            elif isinstance(repository, PostgresStrategyEvaluationRepository):
+                repository.append(value.run.run_id, contradictory)  # type: ignore[arg-type]
+            else:
+                repository.append(contradictory)  # type: ignore[attr-defined]
+
+    follow_up = facts("after-conflict", at=AT + timedelta(hours=2))
+    assert PostgresRunProvenanceRepository(session).add(follow_up.run) == follow_up.run
+
+
+def test_alternate_unique_collisions_raise_typed_conflicts(session: Session) -> None:
+    value = facts("alternate", at=AT + timedelta(hours=3))
+    persist_graph(session, value)
+
+    alternate_config = replace(value.run, config_id=ConfigId("sf045b-config-alternate-other"))
+    with pytest.raises(ContradictoryFactError):
+        PostgresRunProvenanceRepository(session).add(alternate_config)
+
+    alternate_intent = EntryIntent.create(
+        trigger_event_id=value.trigger.trigger_event_id,
+        signal_id=value.signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=value.trigger.reference_price,
+        quantity=Quantity(11),
+        execution_mode=ExecutionMode.PAPER,
+        created_at=value.trigger.observed_at,
+        run=value.run,
+    )
+    with pytest.raises(ContradictoryFactError):
+        PostgresEntryIntentRepository(session).append(alternate_intent)
+
+    alternate_fill = Fill.create(
+        entry_intent_id=value.intent.entry_intent_id,
+        trigger_event_id=value.trigger.trigger_event_id,
+        signal_id=value.signal.signal_id,
+        instrument_id=INSTRUMENT,
+        reference_price=value.trigger.reference_price,
+        fill_price=Price(Decimal("101.25")),
+        quantity=value.intent.quantity,
+        execution_mode=value.intent.execution_mode,
+        filled_at=value.fill.filled_at + timedelta(seconds=1),
+        run=value.run,
+    )
+    with pytest.raises(ContradictoryFactError):
+        PostgresFillRepository(session).append(alternate_fill)
+
+    second = facts("alternate-second", at=AT + timedelta(hours=4))
+    persist_graph(session, second)
+    alternate_exit = replace(
+        second.exit_fact,
+        exit_fill_id=value.exit_fact.exit_fill_id,
+    )
+    with pytest.raises(ContradictoryFactError):
+        PostgresExitRepository(session).append(alternate_exit)
+
+
+def test_caller_rollback_removes_all_repository_writes(postgres_engine: Engine) -> None:
+    value = facts("rollback", at=AT + timedelta(hours=5))
+    with Session(postgres_engine) as caller_session:
+        PostgresRunProvenanceRepository(caller_session).add(value.run)
+        PostgresSignalRepository(caller_session).append(value.signal)
+        caller_session.rollback()
+
+    with Session(postgres_engine) as observer:
+        assert PostgresRunProvenanceRepository(observer).get(value.run.run_id) is None
+        assert PostgresSignalRepository(observer).get(value.signal.signal_id) is None
+
+
+def test_duplicate_from_prior_committed_transaction_is_idempotent(
+    postgres_engine: Engine,
+) -> None:
+    value = facts("committed", at=AT + timedelta(hours=6))
+    with Session(postgres_engine) as first_caller:
+        assert PostgresRunProvenanceRepository(first_caller).add(value.run) == value.run
+        first_caller.commit()
+    try:
+        with Session(postgres_engine) as retrying_caller:
+            assert PostgresRunProvenanceRepository(retrying_caller).add(value.run) == value.run
+            retrying_caller.rollback()
+    finally:
+        with Session(postgres_engine) as cleanup:
+            cleanup.execute(sa.delete(RunRecord).where(RunRecord.run_id == str(value.run.run_id)))
+            cleanup.execute(
+                sa.delete(StrategyConfigRecord).where(
+                    StrategyConfigRecord.config_id == str(value.run.config_id)
+                )
+            )
+            cleanup.commit()

--- a/tests/unit/persistence/test_repository_adapters_unit.py
+++ b/tests/unit/persistence/test_repository_adapters_unit.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import inspect
+
+from signalforge.persistence import repositories
+
+
+def test_postgres_adapters_keep_transaction_ownership_with_caller() -> None:
+    source = inspect.getsource(repositories)
+
+    assert ".commit(" not in source
+    assert ".rollback(" not in source
+    assert "create_engine" not in source
+    assert "sessionmaker" not in source
+    assert "begin_nested" in source
+    assert "on_conflict_do_nothing" in source
+
+
+def test_sf045b_adapter_inventory_excludes_later_issue_repositories() -> None:
+    names = set(vars(repositories))
+
+    assert {
+        "PostgresRunProvenanceRepository",
+        "PostgresStrategyEvaluationRepository",
+        "PostgresSignalRepository",
+        "PostgresTriggerEventRepository",
+        "PostgresEntryIntentRepository",
+        "PostgresFillRepository",
+        "PostgresExitRepository",
+        "PostgresStateTransitionRepository",
+    } <= names
+    assert "PostgresArmedSetupRepository" not in names
+    assert "PostgresTradeRepository" not in names
+    assert "PostgresPositionRepository" not in names
+    assert "UnitOfWork" not in names


### PR DESCRIPTION
## Summary

Implements SF-045B for M6 using the SQL-free contracts and lossless mappings established by SF-045A.

- adds caller-Session PostgreSQL adapters for run/config provenance, StrategyEvaluation, Signal, TriggerEvent, EntryIntent, Fill, Exit, and StateTransition
- preserves caller transaction ownership: repositories do not create engines/sessions and do not call top-level commit/rollback
- implements append-only idempotent immutable writes
- exact duplicate logical writes reuse existing persisted domain facts
- contradictory primary/alternate logical identity collisions raise `ContradictoryFactError`
- handles expected PostgreSQL uniqueness conflicts without poisoning the caller's outer transaction
- reconstructs complete RunIdentity provenance through the accepted SF-045A mapper boundary
- keeps ORM records inside persistence and leaves strategy/runtime modules SQLAlchemy-free

## Validation

Local PostgreSQL-enabled validation completed successfully:

- unit persistence tests: 5 passed
- PostgreSQL integration persistence tests: 11 passed
- plain `pytest -s`: 398 passed, 2 deprecation warnings
- Ruff: passed
- strict mypy: passed
- `git diff --check`: passed
- Alembic revision: `20260901_0002 (head)`

PostgreSQL integration coverage verifies caller rollback, same-session and committed duplicate retries, contradictory duplicates, alternate uniqueness conflicts, typed conflict translation, and continued outer-transaction usability after expected conflict paths.

## Scope discipline

No SF-045C, SF-046, or SF-047 implementation is included. No ArmedSetup/Trade/Position PostgreSQL adapters, Unit of Work, lifecycle transaction coordinator, checkpoint/projection/recovery persistence, broker/OpenAlgo integration, or strategy changes are introduced.

Closes #128
Parent: #101