### PR TITLE
SF-045C — PostgreSQL adapters for authoritative business state

### DIFF
--- a/signalforge/persistence/__init__.py
+++ b/signalforge/persistence/__init__.py
@@ -2,24 +2,30 @@
 
 from signalforge.persistence.models import Base
 from signalforge.persistence.repositories import (
+    PostgresArmedSetupRepository,
     PostgresEntryIntentRepository,
     PostgresExitRepository,
     PostgresFillRepository,
+    PostgresPositionRepository,
     PostgresRunProvenanceRepository,
     PostgresSignalRepository,
     PostgresStateTransitionRepository,
     PostgresStrategyEvaluationRepository,
+    PostgresTradeRepository,
     PostgresTriggerEventRepository,
 )
 
 __all__ = [
     "Base",
+    "PostgresArmedSetupRepository",
     "PostgresEntryIntentRepository",
     "PostgresExitRepository",
     "PostgresFillRepository",
+    "PostgresPositionRepository",
     "PostgresRunProvenanceRepository",
     "PostgresSignalRepository",
     "PostgresStateTransitionRepository",
+    "PostgresTradeRepository",
     "PostgresStrategyEvaluationRepository",
     "PostgresTriggerEventRepository",
 ]

--- a/signalforge/persistence/repositories.py
+++ b/signalforge/persistence/repositories.py
@@ -16,6 +16,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.selectable import FromClause, TableClause
 
+from signalforge.domain.armed import ArmedSetup, ArmedSetupState
 from signalforge.domain.audit import StateTransition
 from signalforge.domain.execution import EntryIntent, Fill, TriggerEvent
 from signalforge.domain.exits import Exit
@@ -24,27 +25,35 @@ from signalforge.domain.ids import (
     ExitId,
     FillId,
     InstrumentId,
+    PositionId,
     RunId,
     SignalId,
     StateTransitionId,
+    TradeId,
     TriggerEventId,
 )
+from signalforge.domain.positions import Position, PositionState
 from signalforge.domain.provenance import RunIdentity
 from signalforge.domain.signals import Signal
 from signalforge.domain.strategy import StrategyEvaluation
 from signalforge.domain.time import CandleInterval
+from signalforge.domain.trades import Trade, TradeState
 from signalforge.persistence.errors import (
     ContradictoryFactError,
     PersistenceDependencyError,
     PersistenceError,
 )
 from signalforge.persistence.mappers import (
+    armed_setup_from_record,
+    armed_setup_record_from_domain,
     entry_intent_from_record,
     entry_intent_record_from_domain,
     exit_from_record,
     exit_record_from_domain,
     fill_from_record,
     fill_record_from_domain,
+    position_from_record,
+    position_record_from_domain,
     run_identity_from_records,
     run_record_from_domain,
     signal_from_record,
@@ -54,10 +63,13 @@ from signalforge.persistence.mappers import (
     strategy_config_record_from_domain,
     strategy_evaluation_from_record,
     strategy_evaluation_record_from_domain,
+    trade_from_record,
+    trade_record_from_domain,
     trigger_event_from_record,
     trigger_event_record_from_domain,
 )
 from signalforge.persistence.models import (
+    ArmedSetupRecord,
     EntryIntentRecord,
     ExitRecord,
     FillRecord,
@@ -81,9 +93,7 @@ def _insert_ignoring_unique_conflicts(
     session.execute(insert(cast(TableClause, table)).values(values).on_conflict_do_nothing())
 
 
-def _single_collision[RecordT](
-    records: Sequence[RecordT], *, fact_name: str
-) -> RecordT | None:
+def _single_collision[RecordT](records: Sequence[RecordT], *, fact_name: str) -> RecordT | None:
     if len(records) > 1:
         raise ContradictoryFactError(
             f"{fact_name} primary and alternate identities resolve to different stored facts"
@@ -109,10 +119,16 @@ def _append_immutable[FactT, RecordT](
         raise PersistenceError(f"{fact_name} insert did not produce a persisted fact")
     persisted = hydrate(existing)
     if persisted != requested:
-        raise ContradictoryFactError(
-            f"stored {fact_name} contradicts requested immutable fact"
-        )
+        raise ContradictoryFactError(f"stored {fact_name} contradicts requested immutable fact")
     return persisted
+
+
+def _same_record_fields(
+    stored: object,
+    candidate: object,
+    fields: tuple[str, ...],
+) -> bool:
+    return all(getattr(stored, field) == getattr(candidate, field) for field in fields)
 
 
 class _PostgresRepository:
@@ -487,3 +503,242 @@ class PostgresStateTransitionRepository(_PostgresRepository):
         if run is None:
             raise PersistenceDependencyError("state transition references missing run provenance")
         return state_transition_from_record(record, run)
+
+
+class PostgresArmedSetupRepository(_PostgresRepository):
+    """Persist authoritative ArmedSetup state with caller-owned transactions."""
+
+    _IMMUTABLE_FIELDS = (
+        "signal_id",
+        "run_id",
+        "raw_trigger",
+        "tradable_trigger",
+        "signal_low",
+        "armed_at",
+        "valid_until",
+    )
+    _STATE_FIELDS = ("state", "terminal_at", "expiry_reason")
+
+    def _require_dependencies(self, run_id: RunId, setup: ArmedSetup) -> None:
+        if self._load_run(run_id) is None:
+            raise PersistenceDependencyError(f"run provenance {run_id!s} must be persisted first")
+        signal = self._require_record(SignalRecord, str(setup.signal_id), name="signal")
+        if signal.run_id != str(run_id):
+            raise ContradictoryFactError("setup run contradicts the persisted signal provenance")
+
+    def upsert(self, run_id: RunId, setup: ArmedSetup) -> ArmedSetup:
+        self._require_dependencies(run_id, setup)
+        candidate = armed_setup_record_from_domain(run_id, setup)
+        stored = self._session.get(ArmedSetupRecord, candidate.signal_id)
+        if stored is None:
+            _insert_ignoring_unique_conflicts(self._session, ArmedSetupRecord.__table__, candidate)
+            self._session.flush()
+            stored = self._session.get(ArmedSetupRecord, candidate.signal_id)
+        if stored is None:
+            raise PersistenceError("armed setup insert produced no persisted record")
+        if not _same_record_fields(stored, candidate, self._IMMUTABLE_FIELDS):
+            raise ContradictoryFactError("stored armed setup contradicts immutable setup anchors")
+        if _same_record_fields(stored, candidate, self._STATE_FIELDS):
+            return armed_setup_from_record(stored)
+        if stored.state != ArmedSetupState.ARMED.value or candidate.state not in {
+            ArmedSetupState.TRIGGERED.value,
+            ArmedSetupState.EXPIRED.value,
+        }:
+            raise ContradictoryFactError("stored armed setup cannot be replaced or regressed")
+        result = cast(
+            sa.CursorResult[object],
+            self._session.execute(
+                sa.update(ArmedSetupRecord)
+                .where(
+                    ArmedSetupRecord.signal_id == candidate.signal_id,
+                    ArmedSetupRecord.state == ArmedSetupState.ARMED.value,
+                )
+                .values(
+                    state=candidate.state,
+                    terminal_at=candidate.terminal_at,
+                    expiry_reason=candidate.expiry_reason,
+                )
+            ),
+        )
+        if result.rowcount == 1:
+            self._session.flush()
+        self._session.expire_all()
+        stored = self._session.get(ArmedSetupRecord, candidate.signal_id)
+        if stored is not None and _same_record_fields(stored, candidate, self._STATE_FIELDS):
+            return armed_setup_from_record(stored)
+        raise ContradictoryFactError("stored armed setup conflicts with requested terminal state")
+
+    def get(self, signal_id: SignalId) -> ArmedSetup | None:
+        record = self._session.get(ArmedSetupRecord, str(signal_id))
+        return None if record is None else armed_setup_from_record(record)
+
+
+class PostgresTradeRepository(_PostgresRepository):
+    """Persist authoritative Trade state while freezing entry economics."""
+
+    _IMMUTABLE_FIELDS = (
+        "trade_id",
+        "entry_fill_id",
+        "signal_id",
+        "run_id",
+        "instrument_id",
+        "entry_price",
+        "stop_price",
+        "raw_target_price",
+        "tradable_target_price",
+        "risk_per_share",
+        "quantity",
+        "opened_at",
+    )
+    _STATE_FIELDS = ("state", "closed_at", "exit_id")
+
+    def _find(self, candidate: TradeRecord) -> TradeRecord | None:
+        records = self._session.scalars(
+            sa.select(TradeRecord).where(
+                sa.or_(
+                    TradeRecord.trade_id == candidate.trade_id,
+                    TradeRecord.entry_fill_id == candidate.entry_fill_id,
+                )
+            )
+        ).all()
+        return _single_collision(records, fact_name="trade")
+
+    def _require_dependencies(self, trade: Trade, candidate: TradeRecord) -> None:
+        self._require_run(trade.run)
+        entry_fill = self._require_record(FillRecord, candidate.entry_fill_id, name="entry fill")
+        signal = self._require_record(SignalRecord, candidate.signal_id, name="signal")
+        if entry_fill.run_id != candidate.run_id or signal.run_id != candidate.run_id:
+            raise ContradictoryFactError(
+                "trade dependencies contradict the requested run provenance"
+            )
+        if candidate.state == TradeState.CLOSED.value:
+            exit_record = self._require_record(ExitRecord, candidate.exit_id or "", name="exit")
+            if exit_record.trade_id != candidate.trade_id:
+                raise ContradictoryFactError("trade close references an exit for a different trade")
+
+    def upsert(self, trade: Trade) -> Trade:
+        candidate = trade_record_from_domain(trade)
+        self._require_dependencies(trade, candidate)
+        stored = self._find(candidate)
+        if stored is None:
+            _insert_ignoring_unique_conflicts(self._session, TradeRecord.__table__, candidate)
+            self._session.flush()
+            stored = self._find(candidate)
+        if stored is None:
+            raise PersistenceError("trade insert produced no persisted record")
+        if not _same_record_fields(stored, candidate, self._IMMUTABLE_FIELDS):
+            raise ContradictoryFactError("stored trade contradicts immutable entry economics")
+        if _same_record_fields(stored, candidate, self._STATE_FIELDS):
+            return trade_from_record(stored, trade.run)
+        if stored.state != TradeState.OPEN.value or candidate.state != TradeState.CLOSED.value:
+            raise ContradictoryFactError("stored trade cannot be replaced or regressed")
+        result = cast(
+            sa.CursorResult[object],
+            self._session.execute(
+                sa.update(TradeRecord)
+                .where(
+                    TradeRecord.trade_id == candidate.trade_id,
+                    TradeRecord.state == TradeState.OPEN.value,
+                )
+                .values(
+                    state=candidate.state,
+                    closed_at=candidate.closed_at,
+                    exit_id=candidate.exit_id,
+                )
+            ),
+        )
+        if result.rowcount == 1:
+            self._session.flush()
+        self._session.expire_all()
+        stored = self._find(candidate)
+        if stored is not None and _same_record_fields(stored, candidate, self._STATE_FIELDS):
+            return trade_from_record(stored, trade.run)
+        raise ContradictoryFactError("stored trade conflicts with requested closed state")
+
+    def get(self, trade_id: TradeId) -> Trade | None:
+        record = self._session.get(TradeRecord, str(trade_id))
+        if record is None:
+            return None
+        run = self._load_run(record.run_id)
+        if run is None:
+            raise PersistenceDependencyError("trade references missing run provenance")
+        return trade_from_record(record, run)
+
+
+class PostgresPositionRepository(_PostgresRepository):
+    """Persist authoritative Position state while freezing MVP exposure facts."""
+
+    _IMMUTABLE_FIELDS = (
+        "position_id",
+        "trade_id",
+        "run_id",
+        "instrument_id",
+        "quantity",
+        "average_entry_price",
+        "opened_at",
+    )
+    _STATE_FIELDS = ("state", "closed_at")
+
+    def _find(self, candidate: PositionRecord) -> PositionRecord | None:
+        records = self._session.scalars(
+            sa.select(PositionRecord).where(
+                sa.or_(
+                    PositionRecord.position_id == candidate.position_id,
+                    PositionRecord.trade_id == candidate.trade_id,
+                )
+            )
+        ).all()
+        return _single_collision(records, fact_name="position")
+
+    def _require_dependencies(self, position: Position, candidate: PositionRecord) -> None:
+        self._require_run(position.run)
+        trade = self._require_record(TradeRecord, candidate.trade_id, name="trade")
+        if trade.run_id != candidate.run_id or trade.instrument_id != candidate.instrument_id:
+            raise ContradictoryFactError("position dependency contradicts the requested exposure")
+
+    def upsert(self, position: Position) -> Position:
+        candidate = position_record_from_domain(position)
+        self._require_dependencies(position, candidate)
+        stored = self._find(candidate)
+        if stored is None:
+            _insert_ignoring_unique_conflicts(self._session, PositionRecord.__table__, candidate)
+            self._session.flush()
+            stored = self._find(candidate)
+        if stored is None:
+            raise PersistenceError("position insert produced no persisted record")
+        if not _same_record_fields(stored, candidate, self._IMMUTABLE_FIELDS):
+            raise ContradictoryFactError("stored position contradicts immutable exposure fields")
+        if _same_record_fields(stored, candidate, self._STATE_FIELDS):
+            return position_from_record(stored, position.run)
+        if (
+            stored.state != PositionState.OPEN.value
+            or candidate.state != PositionState.CLOSED.value
+        ):
+            raise ContradictoryFactError("stored position cannot be replaced or regressed")
+        result = cast(
+            sa.CursorResult[object],
+            self._session.execute(
+                sa.update(PositionRecord)
+                .where(
+                    PositionRecord.position_id == candidate.position_id,
+                    PositionRecord.state == PositionState.OPEN.value,
+                )
+                .values(state=candidate.state, closed_at=candidate.closed_at)
+            ),
+        )
+        if result.rowcount == 1:
+            self._session.flush()
+        self._session.expire_all()
+        stored = self._find(candidate)
+        if stored is not None and _same_record_fields(stored, candidate, self._STATE_FIELDS):
+            return position_from_record(stored, position.run)
+        raise ContradictoryFactError("stored position conflicts with requested closed state")
+
+    def get(self, position_id: PositionId) -> Position | None:
+        record = self._session.get(PositionRecord, str(position_id))
+        if record is None:
+            return None
+        run = self._load_run(record.run_id)
+        if run is None:
+            raise PersistenceDependencyError("position references missing run provenance")
+        return position_from_record(record, run)

--- a/tests/integration/persistence/test_repository_adapters_postgres.py
+++ b/tests/integration/persistence/test_repository_adapters_postgres.py
@@ -11,12 +11,13 @@ import sqlalchemy as sa
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
+from signalforge.domain.armed import ArmedSetup, ArmedSetupState, ExpiryReason
 from signalforge.domain.audit import StateTransition, TransitionEntityType
 from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, TriggerEvent
 from signalforge.domain.exits import Exit, ExitReason
 from signalforge.domain.ids import ConfigId, FillId, InstrumentId, RunId
 from signalforge.domain.money import Price, Quantity
-from signalforge.domain.positions import Position
+from signalforge.domain.positions import Position, PositionState
 from signalforge.domain.provenance import RunIdentity, StrategyIdentity
 from signalforge.domain.signals import Signal
 from signalforge.domain.strategy import (
@@ -27,21 +28,20 @@ from signalforge.domain.strategy import (
     TrendResult,
 )
 from signalforge.domain.time import IST, CandleInterval
-from signalforge.domain.trades import Trade
-from signalforge.persistence.errors import ContradictoryFactError
-from signalforge.persistence.mappers import (
-    position_record_from_domain,
-    trade_record_from_domain,
-)
+from signalforge.domain.trades import Trade, TradeState
+from signalforge.persistence.errors import ContradictoryFactError, PersistenceDependencyError
 from signalforge.persistence.models import RunRecord, StrategyConfigRecord
 from signalforge.persistence.repositories import (
+    PostgresArmedSetupRepository,
     PostgresEntryIntentRepository,
     PostgresExitRepository,
     PostgresFillRepository,
+    PostgresPositionRepository,
     PostgresRunProvenanceRepository,
     PostgresSignalRepository,
     PostgresStateTransitionRepository,
     PostgresStrategyEvaluationRepository,
+    PostgresTradeRepository,
     PostgresTriggerEventRepository,
 )
 
@@ -75,6 +75,7 @@ class Facts:
     run: RunIdentity
     evaluation: StrategyEvaluation
     signal: Signal
+    setup: ArmedSetup
     trigger: TriggerEvent
     intent: EntryIntent
     fill: Fill
@@ -110,6 +111,14 @@ def facts(suffix: str = "base", *, at: datetime = AT) -> Facts:
         signal_low=Price(Decimal("100.00")),
         run=run,
         created_at=interval.end,
+    )
+    setup = ArmedSetup(
+        signal_id=signal.signal_id,
+        raw_trigger=Price(Decimal("101.15")),
+        tradable_trigger=Price(Decimal("101.15")),
+        signal_low=signal.signal_low,
+        armed_at=interval.end,
+        valid_until=interval.end + timedelta(minutes=5),
     )
     trigger = TriggerEvent.create(
         signal_id=signal.signal_id,
@@ -172,6 +181,7 @@ def facts(suffix: str = "base", *, at: datetime = AT) -> Facts:
         run,
         evaluation,
         signal,
+        setup,
         trigger,
         intent,
         fill,
@@ -185,24 +195,21 @@ def facts(suffix: str = "base", *, at: datetime = AT) -> Facts:
 def persist_graph(session: Session, value: Facts) -> None:
     assert PostgresRunProvenanceRepository(session).add(value.run) == value.run
     assert (
-        PostgresStrategyEvaluationRepository(session).append(
-            value.run.run_id, value.evaluation
-        )
+        PostgresStrategyEvaluationRepository(session).append(value.run.run_id, value.evaluation)
         == value.evaluation
     )
     assert PostgresSignalRepository(session).append(value.signal) == value.signal
     assert PostgresTriggerEventRepository(session).append(value.trigger) == value.trigger
     assert PostgresEntryIntentRepository(session).append(value.intent) == value.intent
     assert PostgresFillRepository(session).append(value.fill) == value.fill
-    session.add(trade_record_from_domain(value.trade))
-    session.flush()
-    session.add(position_record_from_domain(value.position))
-    session.flush()
-    assert PostgresExitRepository(session).append(value.exit_fact) == value.exit_fact
     assert (
-        PostgresStateTransitionRepository(session).append(value.transition)
-        == value.transition
+        PostgresArmedSetupRepository(session).upsert(value.run.run_id, value.setup).state
+        is ArmedSetupState.ARMED
     )
+    assert PostgresTradeRepository(session).upsert(value.trade).state is TradeState.OPEN
+    assert PostgresPositionRepository(session).upsert(value.position).state is PositionState.OPEN
+    assert PostgresExitRepository(session).append(value.exit_fact) == value.exit_fact
+    assert PostgresStateTransitionRepository(session).append(value.transition) == value.transition
 
 
 def test_all_immutable_repositories_round_trip_and_retry_exactly(session: Session) -> None:
@@ -221,8 +228,7 @@ def test_all_immutable_repositories_round_trip_and_retry_exactly(session: Sessio
     assert provenance.add(value.run) == provenance.get(value.run.run_id) == value.run
     assert evaluations.append(value.run.run_id, value.evaluation) == value.evaluation
     assert (
-        evaluations.get(value.run.run_id, INSTRUMENT, value.evaluation.interval)
-        == value.evaluation
+        evaluations.get(value.run.run_id, INSTRUMENT, value.evaluation.interval) == value.evaluation
     )
     assert signals.append(value.signal) == signals.get(value.signal.signal_id) == value.signal
     assert (
@@ -230,26 +236,19 @@ def test_all_immutable_repositories_round_trip_and_retry_exactly(session: Sessio
         == triggers.get(value.trigger.trigger_event_id)
         == value.trigger
     )
-    assert (
-        intents.append(value.intent)
-        == intents.get(value.intent.entry_intent_id)
-        == value.intent
-    )
+    assert intents.append(value.intent) == intents.get(value.intent.entry_intent_id) == value.intent
     assert fills.append(value.fill) == fills.get(value.fill.fill_id) == value.fill
-    assert (
-        exits.append(value.exit_fact)
-        == exits.get(value.exit_fact.exit_id)
-        == value.exit_fact
-    )
+    assert exits.append(value.exit_fact) == exits.get(value.exit_fact.exit_id) == value.exit_fact
     assert (
         transitions.append(value.transition)
         == transitions.get(value.transition.transition_id)
         == value.transition
     )
-    assert exits.get(value.exit_fact.exit_id).realised_r.as_tuple() == (
-        value.exit_fact.realised_r.as_tuple()
-    )
-    assert signals.get(value.signal.signal_id).created_at == value.signal.created_at
+    stored_exit = exits.get(value.exit_fact.exit_id)
+    stored_signal = signals.get(value.signal.signal_id)
+    assert stored_exit is not None and stored_signal is not None
+    assert stored_exit.realised_r.as_tuple() == value.exit_fact.realised_r.as_tuple()
+    assert stored_signal.created_at == value.signal.created_at
 
 
 def test_contradictory_reuse_is_typed_and_outer_transaction_remains_usable(
@@ -394,3 +393,147 @@ def test_duplicate_from_prior_committed_transaction_is_idempotent(
                 )
             )
             cleanup.commit()
+
+
+def test_authoritative_repositories_apply_forward_transitions_and_terminal_retries(
+    session: Session,
+) -> None:
+    value = facts("authoritative", at=AT + timedelta(hours=7))
+    persist_graph(session, value)
+
+    setups = PostgresArmedSetupRepository(session)
+    trades = PostgresTradeRepository(session)
+    positions = PostgresPositionRepository(session)
+
+    assert setups.upsert(value.run.run_id, value.setup).state is ArmedSetupState.ARMED
+    triggered = replace(value.setup)
+    triggered.trigger(at=value.setup.armed_at + timedelta(minutes=1))
+    assert triggered.terminal_at is not None
+    assert setups.upsert(value.run.run_id, triggered).terminal_at == triggered.terminal_at
+    assert setups.upsert(value.run.run_id, triggered).terminal_at == triggered.terminal_at
+    stored_triggered = setups.get(value.setup.signal_id)
+    assert stored_triggered is not None
+    assert stored_triggered.state is ArmedSetupState.TRIGGERED
+
+    closed_trade = replace(value.trade)
+    closed_trade.close(exit_id=value.exit_fact.exit_id, at=value.exit_fact.exited_at)
+    assert closed_trade.closed_at is not None
+    closed_position = replace(value.position)
+    closed_position.close(at=value.exit_fact.exited_at)
+    assert closed_position.closed_at is not None
+    assert trades.upsert(closed_trade).closed_at == closed_trade.closed_at
+    assert trades.upsert(closed_trade).closed_at == closed_trade.closed_at
+    assert positions.upsert(closed_position).closed_at == closed_position.closed_at
+    assert positions.upsert(closed_position).closed_at == closed_position.closed_at
+
+    expired_value = facts("expired", at=AT + timedelta(hours=8))
+    persist_graph(session, expired_value)
+    expired = replace(expired_value.setup)
+    expired.expire(at=expired.valid_until, reason=ExpiryReason.VALIDITY_WINDOW_END)
+    assert (
+        setups.upsert(expired_value.run.run_id, expired).expiry_reason
+        is ExpiryReason.VALIDITY_WINDOW_END
+    )
+    assert (
+        setups.upsert(expired_value.run.run_id, expired).expiry_reason
+        is ExpiryReason.VALIDITY_WINDOW_END
+    )
+    stored_expired = setups.get(expired.signal_id)
+    assert stored_expired is not None
+    assert stored_expired.state is ArmedSetupState.EXPIRED
+
+
+def test_authoritative_repositories_reject_conflicts_and_keep_outer_transaction_usable(
+    session: Session,
+) -> None:
+    value = facts("state-conflict", at=AT + timedelta(hours=9))
+    persist_graph(session, value)
+    setups = PostgresArmedSetupRepository(session)
+    trades = PostgresTradeRepository(session)
+    positions = PostgresPositionRepository(session)
+
+    with pytest.raises(ContradictoryFactError):
+        setups.upsert(value.run.run_id, replace(value.setup, raw_trigger=Price(Decimal("101.14"))))
+
+    triggered = replace(value.setup)
+    triggered.trigger(at=value.setup.armed_at + timedelta(minutes=1))
+    assert triggered.terminal_at is not None
+    assert setups.upsert(value.run.run_id, triggered).terminal_at == triggered.terminal_at
+    with pytest.raises(ContradictoryFactError):
+        setups.upsert(value.run.run_id, value.setup)
+    with pytest.raises(ContradictoryFactError):
+        setups.upsert(
+            value.run.run_id,
+            replace(triggered, terminal_at=triggered.terminal_at + timedelta(seconds=1)),
+        )
+    with pytest.raises(ContradictoryFactError):
+        setups.upsert(
+            value.run.run_id,
+            replace(
+                triggered,
+                state=ArmedSetupState.EXPIRED,
+                expiry_reason=ExpiryReason.VALIDITY_WINDOW_END,
+            ),
+        )
+
+    changed_economics = replace(
+        value.trade,
+        stop_price=Price(Decimal("100.10")),
+        risk_per_share=Price(Decimal("1.10")),
+        raw_target_price=Price(Decimal("102.85")),
+        tradable_target_price=Price(Decimal("102.85")),
+    )
+    with pytest.raises(ContradictoryFactError):
+        trades.upsert(changed_economics)
+
+    closed_trade = replace(value.trade)
+    closed_trade.close(exit_id=value.exit_fact.exit_id, at=value.exit_fact.exited_at)
+    assert closed_trade.closed_at is not None
+    assert trades.upsert(closed_trade).closed_at == closed_trade.closed_at
+    with pytest.raises(ContradictoryFactError):
+        trades.upsert(value.trade)
+    with pytest.raises(ContradictoryFactError):
+        trades.upsert(
+            replace(closed_trade, closed_at=closed_trade.closed_at + timedelta(seconds=1))
+        )
+
+    with pytest.raises(ContradictoryFactError):
+        positions.upsert(replace(value.position, average_entry_price=Price(Decimal("101.25"))))
+    closed_position = replace(value.position)
+    closed_position.close(at=value.exit_fact.exited_at)
+    assert closed_position.closed_at is not None
+    assert positions.upsert(closed_position).closed_at == closed_position.closed_at
+    with pytest.raises(ContradictoryFactError):
+        positions.upsert(value.position)
+    with pytest.raises(ContradictoryFactError):
+        positions.upsert(
+            replace(closed_position, closed_at=closed_position.closed_at + timedelta(seconds=1))
+        )
+
+    follow_up = facts("after-state-conflict", at=AT + timedelta(hours=10))
+    persist_graph(session, follow_up)
+
+
+def test_authoritative_repository_writes_are_owned_by_caller_rollback(
+    postgres_engine: Engine,
+) -> None:
+    value = facts("state-rollback", at=AT + timedelta(hours=11))
+    with Session(postgres_engine) as caller_session:
+        persist_graph(caller_session, value)
+        caller_session.rollback()
+
+    with Session(postgres_engine) as observer:
+        assert PostgresArmedSetupRepository(observer).get(value.setup.signal_id) is None
+        assert PostgresTradeRepository(observer).get(value.trade.trade_id) is None
+        assert PostgresPositionRepository(observer).get(value.position.position_id) is None
+
+
+def test_authoritative_repositories_require_persisted_dependencies(session: Session) -> None:
+    value = facts("missing-dependencies", at=AT + timedelta(hours=12))
+
+    with pytest.raises(PersistenceDependencyError):
+        PostgresArmedSetupRepository(session).upsert(value.run.run_id, value.setup)
+    with pytest.raises(PersistenceDependencyError):
+        PostgresTradeRepository(session).upsert(value.trade)
+    with pytest.raises(PersistenceDependencyError):
+        PostgresPositionRepository(session).upsert(value.position)

--- a/tests/unit/persistence/test_repository_adapters_unit.py
+++ b/tests/unit/persistence/test_repository_adapters_unit.py
@@ -16,7 +16,7 @@ def test_postgres_adapters_keep_transaction_ownership_with_caller() -> None:
     assert "on_conflict_do_nothing" in source
 
 
-def test_sf045b_adapter_inventory_excludes_later_issue_repositories() -> None:
+def test_sf045_adapter_inventory_includes_only_accepted_repositories() -> None:
     names = set(vars(repositories))
 
     assert {
@@ -29,7 +29,21 @@ def test_sf045b_adapter_inventory_excludes_later_issue_repositories() -> None:
         "PostgresExitRepository",
         "PostgresStateTransitionRepository",
     } <= names
-    assert "PostgresArmedSetupRepository" not in names
-    assert "PostgresTradeRepository" not in names
-    assert "PostgresPositionRepository" not in names
+    assert {
+        "PostgresArmedSetupRepository",
+        "PostgresTradeRepository",
+        "PostgresPositionRepository",
+    } <= names
     assert "UnitOfWork" not in names
+    assert "PostgresCheckpointRepository" not in names
+    assert "PostgresLifecycleProjectionRepository" not in names
+
+
+def test_authoritative_adapters_use_conditional_predecessor_updates() -> None:
+    source = inspect.getsource(repositories)
+
+    assert source.count("sa.update(") >= 3
+    assert "ArmedSetupRecord.state == ArmedSetupState.ARMED.value" in source
+    assert "TradeRecord.state == TradeState.OPEN.value" in source
+    assert "PositionRecord.state == PositionState.OPEN.value" in source
+    assert source.count("self._session.expire_all()") >= 3


### PR DESCRIPTION
## Summary

Implements SF-045C for M6 using the SQL-free contracts/mappers from SF-045A and the caller-Session adapter conventions established by SF-045B.

- adds PostgreSQL adapters for ArmedSetup, Trade, and Position only
- preserves caller transaction ownership: repositories do not create engines/sessions and do not call top-level commit/rollback
- supports insert, exact retry, and allowed forward authoritative-state update semantics
- protects immutable identity/economic fields from overwrite
- restricts persisted state changes to the existing domain lifecycle transitions
- uses conditional predecessor-state updates to prevent stale-state regression or terminal replacement
- translates contradictions to typed persistence errors and missing parents to PersistenceDependencyError
- keeps ORM records inside persistence and introduces no schema migration

## Accepted transition matrix

- ArmedSetup: ARMED → TRIGGERED or ARMED → EXPIRED; both terminal
- Trade: OPEN → CLOSED; CLOSED terminal
- Position: OPEN → CLOSED; CLOSED terminal

## Validation

Local PostgreSQL-enabled validation completed successfully:

- unit persistence tests: 6 passed
- PostgreSQL integration persistence tests: 15 passed, 2 existing Alembic warnings
- full `pytest -s`: 403 passed, 2 existing Alembic warnings
- Ruff: passed
- strict mypy: passed (48 source files)
- `git diff --check`: passed
- Alembic revision: `20260901_0002 (head)`

Integration coverage verifies valid forward updates, exact retries including terminal retries, immutable-field mismatch rejection, invalid regression/terminal replacement rejection, missing dependency handling, caller rollback, expected-conflict outer transaction usability, and conditional predecessor-state guards.

## Scope discipline

No SF-046 Unit of Work/transaction orchestration and no SF-047 checkpoint/lifecycle projection persistence are included. No recovery, broker/OpenAlgo, event-sourcing, strategy, or lifecycle semantic changes are introduced.

Closes #129
Parent: #101