### PR TITLE
SF-046 — Atomic persistence boundaries and idempotent transition writes

### DIFF
--- a/alembic/versions/20260902_0003_add_position_open_outcomes.py
+++ b/alembic/versions/20260902_0003_add_position_open_outcomes.py
@@ -1,0 +1,47 @@
+"""Add durable immutable outcomes for completed position-open attempts.
+
+Revision ID: 20260902_0003
+Revises: 20260901_0002
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260902_0003"
+down_revision: str | None = "20260901_0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "position_open_outcomes",
+        sa.Column("outcome_id", sa.String(length=64), nullable=False),
+        sa.Column("fill_id", sa.String(length=64), nullable=False),
+        sa.Column("run_id", sa.String(length=64), nullable=False),
+        sa.Column("outcome", sa.String(length=64), nullable=False),
+        sa.CheckConstraint(
+            "outcome IN ('opened', 'rejected_non_positive_risk')",
+            name="ck_position_open_outcomes_outcome",
+        ),
+        sa.ForeignKeyConstraint(
+            ["fill_id"],
+            ["fills.fill_id"],
+            name="fk_position_open_outcomes_fill_id_fills",
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"],
+            ["runs.run_id"],
+            name="fk_position_open_outcomes_run_id_runs",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("outcome_id", name="pk_position_open_outcomes"),
+        sa.UniqueConstraint("fill_id", name="uq_position_open_outcomes_fill"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("position_open_outcomes")

--- a/alembic/versions/20260902_0003_add_position_open_outcomes.py
+++ b/alembic/versions/20260902_0003_add_position_open_outcomes.py
@@ -21,8 +21,10 @@ def upgrade() -> None:
         "position_open_outcomes",
         sa.Column("outcome_id", sa.String(length=64), nullable=False),
         sa.Column("fill_id", sa.String(length=64), nullable=False),
+        sa.Column("signal_id", sa.String(length=64), nullable=False),
         sa.Column("run_id", sa.String(length=64), nullable=False),
         sa.Column("outcome", sa.String(length=64), nullable=False),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=False),
         sa.CheckConstraint(
             "outcome IN ('opened', 'rejected_non_positive_risk')",
             name="ck_position_open_outcomes_outcome",
@@ -31,6 +33,13 @@ def upgrade() -> None:
             ["fill_id"],
             ["fills.fill_id"],
             name="fk_position_open_outcomes_fill_id_fills",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["signal_id"],
+            ["signals.signal_id"],
+            name="fk_position_open_outcomes_signal_id_signals",
+            ondelete="RESTRICT",
         ),
         sa.ForeignKeyConstraint(
             ["run_id"],

--- a/signalforge/domain/ids.py
+++ b/signalforge/domain/ids.py
@@ -61,6 +61,11 @@ class PositionId(_IdBase):
 
 
 @dataclass(frozen=True, slots=True)
+class PositionOpenOutcomeId(_IdBase):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
 class ExitId(_IdBase):
     pass
 

--- a/signalforge/domain/position_outcomes.py
+++ b/signalforge/domain/position_outcomes.py
@@ -1,0 +1,42 @@
+"""Immutable durable outcome of attempting to open a position from a Fill."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from signalforge.domain.ids import FillId, PositionOpenOutcomeId, deterministic_id
+from signalforge.domain.provenance import RunIdentity
+
+
+class PositionOpenOutcomeType(StrEnum):
+    OPENED = "opened"
+    REJECTED_NON_POSITIVE_RISK = "rejected_non_positive_risk"
+
+
+@dataclass(frozen=True, slots=True)
+class PositionOpenOutcome:
+    """One deterministic immutable completion outcome for one accepted entry Fill."""
+
+    outcome_id: PositionOpenOutcomeId
+    fill_id: FillId
+    outcome: PositionOpenOutcomeType
+    run: RunIdentity
+
+    def __post_init__(self) -> None:
+        if self.outcome_id != self.expected_id():
+            raise ValueError("PositionOpenOutcome ID does not match deterministic identity")
+
+    @classmethod
+    def create(
+        cls, *, fill_id: FillId, outcome: PositionOpenOutcomeType, run: RunIdentity
+    ) -> PositionOpenOutcome:
+        return cls(
+            outcome_id=deterministic_id(PositionOpenOutcomeId, str(run.run_id), str(fill_id)),
+            fill_id=fill_id,
+            outcome=outcome,
+            run=run,
+        )
+
+    def expected_id(self) -> PositionOpenOutcomeId:
+        return deterministic_id(PositionOpenOutcomeId, str(self.run.run_id), str(self.fill_id))

--- a/signalforge/domain/position_outcomes.py
+++ b/signalforge/domain/position_outcomes.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 
-from signalforge.domain.ids import FillId, PositionOpenOutcomeId, deterministic_id
+from signalforge.domain.ids import FillId, PositionOpenOutcomeId, SignalId, deterministic_id
 from signalforge.domain.provenance import RunIdentity
+from signalforge.domain.time import require_aware
 
 
 class PositionOpenOutcomeType(StrEnum):
@@ -20,21 +22,32 @@ class PositionOpenOutcome:
 
     outcome_id: PositionOpenOutcomeId
     fill_id: FillId
+    signal_id: SignalId
     outcome: PositionOpenOutcomeType
+    decided_at: datetime
     run: RunIdentity
 
     def __post_init__(self) -> None:
+        require_aware(self.decided_at)
         if self.outcome_id != self.expected_id():
             raise ValueError("PositionOpenOutcome ID does not match deterministic identity")
 
     @classmethod
     def create(
-        cls, *, fill_id: FillId, outcome: PositionOpenOutcomeType, run: RunIdentity
+        cls,
+        *,
+        fill_id: FillId,
+        signal_id: SignalId,
+        outcome: PositionOpenOutcomeType,
+        decided_at: datetime,
+        run: RunIdentity,
     ) -> PositionOpenOutcome:
         return cls(
             outcome_id=deterministic_id(PositionOpenOutcomeId, str(run.run_id), str(fill_id)),
             fill_id=fill_id,
+            signal_id=signal_id,
             outcome=outcome,
+            decided_at=decided_at,
             run=run,
         )
 

--- a/signalforge/persistence/__init__.py
+++ b/signalforge/persistence/__init__.py
@@ -1,11 +1,13 @@
 """PostgreSQL persistence metadata and infrastructure boundaries."""
 
+from signalforge.persistence.coordinator import PersistenceCoordinator
 from signalforge.persistence.models import Base
 from signalforge.persistence.repositories import (
     PostgresArmedSetupRepository,
     PostgresEntryIntentRepository,
     PostgresExitRepository,
     PostgresFillRepository,
+    PostgresPositionOpenOutcomeRepository,
     PostgresPositionRepository,
     PostgresRunProvenanceRepository,
     PostgresSignalRepository,
@@ -17,10 +19,12 @@ from signalforge.persistence.repositories import (
 
 __all__ = [
     "Base",
+    "PersistenceCoordinator",
     "PostgresArmedSetupRepository",
     "PostgresEntryIntentRepository",
     "PostgresExitRepository",
     "PostgresFillRepository",
+    "PostgresPositionOpenOutcomeRepository",
     "PostgresPositionRepository",
     "PostgresRunProvenanceRepository",
     "PostgresSignalRepository",

--- a/signalforge/persistence/contracts.py
+++ b/signalforge/persistence/contracts.py
@@ -14,12 +14,14 @@ from signalforge.domain.ids import (
     FillId,
     InstrumentId,
     PositionId,
+    PositionOpenOutcomeId,
     RunId,
     SignalId,
     StateTransitionId,
     TradeId,
     TriggerEventId,
 )
+from signalforge.domain.position_outcomes import PositionOpenOutcome
 from signalforge.domain.positions import Position
 from signalforge.domain.provenance import RunIdentity
 from signalforge.domain.signals import Signal
@@ -89,6 +91,12 @@ class PositionRepository(Protocol):
     def upsert(self, position: Position) -> Position: ...
 
     def get(self, position_id: PositionId) -> Position | None: ...
+
+
+class PositionOpenOutcomeRepository(Protocol):
+    def append(self, outcome: PositionOpenOutcome) -> PositionOpenOutcome: ...
+
+    def get(self, outcome_id: PositionOpenOutcomeId) -> PositionOpenOutcome | None: ...
 
 
 class ExitRepository(Protocol):

--- a/signalforge/persistence/coordinator.py
+++ b/signalforge/persistence/coordinator.py
@@ -1,0 +1,139 @@
+"""Narrow atomic persistence boundaries for accepted lifecycle outcomes."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from signalforge.domain.armed import ArmedSetup
+from signalforge.domain.audit import StateTransition
+from signalforge.domain.execution import EntryIntent, Fill, TriggerEvent
+from signalforge.domain.exits import Exit
+from signalforge.domain.ids import RunId
+from signalforge.domain.position_outcomes import PositionOpenOutcome, PositionOpenOutcomeType
+from signalforge.domain.positions import Position
+from signalforge.domain.signals import Signal
+from signalforge.domain.strategy import StrategyEvaluation
+from signalforge.domain.trades import Trade
+from signalforge.persistence.repositories import (
+    PostgresArmedSetupRepository,
+    PostgresEntryIntentRepository,
+    PostgresExitRepository,
+    PostgresFillRepository,
+    PostgresPositionOpenOutcomeRepository,
+    PostgresPositionRepository,
+    PostgresSignalRepository,
+    PostgresStateTransitionRepository,
+    PostgresStrategyEvaluationRepository,
+    PostgresTradeRepository,
+    PostgresTriggerEventRepository,
+)
+
+
+class PersistenceCoordinator:
+    """Commit one accepted lifecycle boundary with one caller-provided Session."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def persist_actionable_evaluation(
+        self,
+        *,
+        evaluation: StrategyEvaluation,
+        signal: Signal,
+        setup: ArmedSetup,
+        setup_transition: StateTransition,
+    ) -> tuple[StrategyEvaluation, Signal, ArmedSetup, StateTransition]:
+        with self._session.begin():
+            evaluation = PostgresStrategyEvaluationRepository(self._session).append(
+                signal.run.run_id, evaluation
+            )
+            signal = PostgresSignalRepository(self._session).append(signal)
+            setup = PostgresArmedSetupRepository(self._session).upsert(signal.run.run_id, setup)
+            transition = PostgresStateTransitionRepository(self._session).append(setup_transition)
+        return evaluation, signal, setup, transition
+
+    def persist_trigger_intent(
+        self,
+        *,
+        trigger: TriggerEvent,
+        intent: EntryIntent,
+        setup: ArmedSetup,
+        setup_transition: StateTransition,
+    ) -> tuple[TriggerEvent, EntryIntent, ArmedSetup, StateTransition]:
+        with self._session.begin():
+            trigger = PostgresTriggerEventRepository(self._session).append(trigger)
+            intent = PostgresEntryIntentRepository(self._session).append(intent)
+            setup = PostgresArmedSetupRepository(self._session).upsert(trigger.run.run_id, setup)
+            transition = PostgresStateTransitionRepository(self._session).append(setup_transition)
+        return trigger, intent, setup, transition
+
+    def persist_expiry(
+        self,
+        *,
+        run_id: RunId,
+        setup: ArmedSetup,
+        setup_transition: StateTransition,
+    ) -> tuple[ArmedSetup, StateTransition]:
+        with self._session.begin():
+            setup = PostgresArmedSetupRepository(self._session).upsert(run_id, setup)
+            transition = PostgresStateTransitionRepository(self._session).append(setup_transition)
+        return setup, transition
+
+    def persist_opened_entry(
+        self,
+        *,
+        fill: Fill,
+        outcome: PositionOpenOutcome,
+        trade: Trade,
+        position: Position,
+        trade_transition: StateTransition,
+        position_transition: StateTransition,
+    ) -> tuple[Fill, PositionOpenOutcome, Trade, Position, StateTransition, StateTransition]:
+        if outcome.outcome is not PositionOpenOutcomeType.OPENED:
+            raise ValueError("opened entry requires an OPENED PositionOpenOutcome")
+        with self._session.begin():
+            fill = PostgresFillRepository(self._session).append(fill)
+            outcome = PostgresPositionOpenOutcomeRepository(self._session).append(outcome)
+            trade = PostgresTradeRepository(self._session).upsert(trade)
+            position = PostgresPositionRepository(self._session).upsert(position)
+            trade_transition = PostgresStateTransitionRepository(self._session).append(
+                trade_transition
+            )
+            position_transition = PostgresStateTransitionRepository(self._session).append(
+                position_transition
+            )
+        return fill, outcome, trade, position, trade_transition, position_transition
+
+    def persist_rejected_entry(
+        self,
+        *,
+        fill: Fill,
+        outcome: PositionOpenOutcome,
+    ) -> tuple[Fill, PositionOpenOutcome]:
+        if outcome.outcome is not PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK:
+            raise ValueError("rejected entry requires a rejection PositionOpenOutcome")
+        with self._session.begin():
+            fill = PostgresFillRepository(self._session).append(fill)
+            outcome = PostgresPositionOpenOutcomeRepository(self._session).append(outcome)
+        return fill, outcome
+
+    def persist_exit(
+        self,
+        *,
+        exit_fact: Exit,
+        trade: Trade,
+        position: Position,
+        trade_transition: StateTransition,
+        position_transition: StateTransition,
+    ) -> tuple[Exit, Trade, Position, StateTransition, StateTransition]:
+        with self._session.begin():
+            exit_fact = PostgresExitRepository(self._session).append(exit_fact)
+            trade = PostgresTradeRepository(self._session).upsert(trade)
+            position = PostgresPositionRepository(self._session).upsert(position)
+            trade_transition = PostgresStateTransitionRepository(self._session).append(
+                trade_transition
+            )
+            position_transition = PostgresStateTransitionRepository(self._session).append(
+                position_transition
+            )
+        return exit_fact, trade, position, trade_transition, position_transition

--- a/signalforge/persistence/mappers.py
+++ b/signalforge/persistence/mappers.py
@@ -13,6 +13,7 @@ from signalforge.domain.ids import (
     FillId,
     InstrumentId,
     PositionId,
+    PositionOpenOutcomeId,
     RunId,
     SignalId,
     StateTransitionId,
@@ -20,6 +21,7 @@ from signalforge.domain.ids import (
     TriggerEventId,
 )
 from signalforge.domain.money import Price, Quantity
+from signalforge.domain.position_outcomes import PositionOpenOutcome, PositionOpenOutcomeType
 from signalforge.domain.positions import Position, PositionState
 from signalforge.domain.provenance import RunIdentity, StrategyIdentity
 from signalforge.domain.signals import Signal
@@ -37,6 +39,7 @@ from signalforge.persistence.models import (
     EntryIntentRecord,
     ExitRecord,
     FillRecord,
+    PositionOpenOutcomeRecord,
     PositionRecord,
     RunRecord,
     SignalRecord,
@@ -322,6 +325,28 @@ def position_from_record(record: PositionRecord, run: RunIdentity) -> Position:
         run=run,
         state=PositionState(record.state),
         closed_at=record.closed_at,
+    )
+
+
+def position_open_outcome_record_from_domain(
+    outcome: PositionOpenOutcome,
+) -> PositionOpenOutcomeRecord:
+    return PositionOpenOutcomeRecord(
+        outcome_id=str(outcome.outcome_id),
+        fill_id=str(outcome.fill_id),
+        run_id=str(outcome.run.run_id),
+        outcome=outcome.outcome.value,
+    )
+
+
+def position_open_outcome_from_record(
+    record: PositionOpenOutcomeRecord, run: RunIdentity
+) -> PositionOpenOutcome:
+    return PositionOpenOutcome(
+        outcome_id=PositionOpenOutcomeId(record.outcome_id),
+        fill_id=FillId(record.fill_id),
+        outcome=PositionOpenOutcomeType(record.outcome),
+        run=run,
     )
 
 

--- a/signalforge/persistence/mappers.py
+++ b/signalforge/persistence/mappers.py
@@ -334,8 +334,10 @@ def position_open_outcome_record_from_domain(
     return PositionOpenOutcomeRecord(
         outcome_id=str(outcome.outcome_id),
         fill_id=str(outcome.fill_id),
+        signal_id=str(outcome.signal_id),
         run_id=str(outcome.run.run_id),
         outcome=outcome.outcome.value,
+        decided_at=outcome.decided_at,
     )
 
 
@@ -345,7 +347,9 @@ def position_open_outcome_from_record(
     return PositionOpenOutcome(
         outcome_id=PositionOpenOutcomeId(record.outcome_id),
         fill_id=FillId(record.fill_id),
+        signal_id=SignalId(record.signal_id),
         outcome=PositionOpenOutcomeType(record.outcome),
+        decided_at=record.decided_at,
         run=run,
     )
 

--- a/signalforge/persistence/models.py
+++ b/signalforge/persistence/models.py
@@ -278,6 +278,27 @@ class FillRecord(Base):
     filled_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
+class PositionOpenOutcomeRecord(Base):
+    """Immutable completed business outcome for one accepted entry fill."""
+
+    __tablename__ = "position_open_outcomes"
+    __table_args__ = (
+        UniqueConstraint("fill_id", name="uq_position_open_outcomes_fill"),
+        CheckConstraint(
+            "outcome IN ('opened', 'rejected_non_positive_risk')",
+            name="ck_position_open_outcomes_outcome",
+        ),
+    )
+    outcome_id: Mapped[str] = mapped_column(String(ID_LENGTH), primary_key=True)
+    fill_id: Mapped[str] = mapped_column(
+        ForeignKey("fills.fill_id", ondelete="RESTRICT"), nullable=False
+    )
+    run_id: Mapped[str] = mapped_column(
+        ForeignKey("runs.run_id", ondelete="CASCADE"), nullable=False
+    )
+    outcome: Mapped[str] = mapped_column(String(64), nullable=False)
+
+
 class TradeRecord(Base):
     """Authoritative trade economics and current trade lifecycle state."""
 

--- a/signalforge/persistence/models.py
+++ b/signalforge/persistence/models.py
@@ -293,10 +293,14 @@ class PositionOpenOutcomeRecord(Base):
     fill_id: Mapped[str] = mapped_column(
         ForeignKey("fills.fill_id", ondelete="RESTRICT"), nullable=False
     )
+    signal_id: Mapped[str] = mapped_column(
+        ForeignKey("signals.signal_id", ondelete="RESTRICT"), nullable=False
+    )
     run_id: Mapped[str] = mapped_column(
         ForeignKey("runs.run_id", ondelete="CASCADE"), nullable=False
     )
     outcome: Mapped[str] = mapped_column(String(64), nullable=False)
+    decided_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
 class TradeRecord(Base):

--- a/signalforge/persistence/repositories.py
+++ b/signalforge/persistence/repositories.py
@@ -462,6 +462,11 @@ class PostgresPositionOpenOutcomeRepository(_PostgresRepository):
     def append(self, outcome: PositionOpenOutcome) -> PositionOpenOutcome:
         run = self._require_run(outcome.run)
         fill = self._require_record(FillRecord, str(outcome.fill_id), name="fill")
+        signal = self._require_record(SignalRecord, str(outcome.signal_id), name="signal")
+        if signal.run_id != str(outcome.run.run_id):
+            raise ContradictoryFactError("position open outcome contradicts signal provenance")
+        if fill.signal_id != str(outcome.signal_id):
+            raise ContradictoryFactError("position open outcome contradicts fill signal")
         if fill.run_id != str(outcome.run.run_id):
             raise ContradictoryFactError("position open outcome contradicts fill provenance")
         candidate = position_open_outcome_record_from_domain(outcome)

--- a/signalforge/persistence/repositories.py
+++ b/signalforge/persistence/repositories.py
@@ -26,12 +26,14 @@ from signalforge.domain.ids import (
     FillId,
     InstrumentId,
     PositionId,
+    PositionOpenOutcomeId,
     RunId,
     SignalId,
     StateTransitionId,
     TradeId,
     TriggerEventId,
 )
+from signalforge.domain.position_outcomes import PositionOpenOutcome
 from signalforge.domain.positions import Position, PositionState
 from signalforge.domain.provenance import RunIdentity
 from signalforge.domain.signals import Signal
@@ -53,6 +55,8 @@ from signalforge.persistence.mappers import (
     fill_from_record,
     fill_record_from_domain,
     position_from_record,
+    position_open_outcome_from_record,
+    position_open_outcome_record_from_domain,
     position_record_from_domain,
     run_identity_from_records,
     run_record_from_domain,
@@ -73,6 +77,7 @@ from signalforge.persistence.models import (
     EntryIntentRecord,
     ExitRecord,
     FillRecord,
+    PositionOpenOutcomeRecord,
     PositionRecord,
     RunRecord,
     SignalRecord,
@@ -438,6 +443,48 @@ class PostgresFillRepository(_PostgresRepository):
         if run is None:
             raise PersistenceDependencyError("fill references missing run provenance")
         return fill_from_record(record, run)
+
+
+class PostgresPositionOpenOutcomeRepository(_PostgresRepository):
+    """Persist one immutable completed open outcome for each entry Fill."""
+
+    def _find(self, outcome: PositionOpenOutcome) -> PositionOpenOutcomeRecord | None:
+        records = self._session.scalars(
+            sa.select(PositionOpenOutcomeRecord).where(
+                sa.or_(
+                    PositionOpenOutcomeRecord.outcome_id == str(outcome.outcome_id),
+                    PositionOpenOutcomeRecord.fill_id == str(outcome.fill_id),
+                )
+            )
+        ).all()
+        return _single_collision(records, fact_name="position open outcome")
+
+    def append(self, outcome: PositionOpenOutcome) -> PositionOpenOutcome:
+        run = self._require_run(outcome.run)
+        fill = self._require_record(FillRecord, str(outcome.fill_id), name="fill")
+        if fill.run_id != str(outcome.run.run_id):
+            raise ContradictoryFactError("position open outcome contradicts fill provenance")
+        candidate = position_open_outcome_record_from_domain(outcome)
+        return _append_immutable(
+            session=self._session,
+            table=PositionOpenOutcomeRecord.__table__,
+            record=candidate,
+            requested=outcome,
+            find_existing=lambda: self._find(outcome),
+            hydrate=lambda record: position_open_outcome_from_record(record, run),
+            fact_name="position open outcome",
+        )
+
+    def get(self, outcome_id: PositionOpenOutcomeId) -> PositionOpenOutcome | None:
+        record = self._session.get(PositionOpenOutcomeRecord, str(outcome_id))
+        if record is None:
+            return None
+        run = self._load_run(record.run_id)
+        if run is None:
+            raise PersistenceDependencyError(
+                "position open outcome references missing run provenance"
+            )
+        return position_open_outcome_from_record(record, run)
 
 
 class PostgresExitRepository(_PostgresRepository):

--- a/tests/integration/persistence/test_migrations.py
+++ b/tests/integration/persistence/test_migrations.py
@@ -19,6 +19,7 @@ EXPECTED_TABLES = {
     "indicator_checkpoints",
     "lifecycle_state",
     "positions",
+    "position_open_outcomes",
     "runs",
     "signals",
     "state_transitions",

--- a/tests/integration/persistence/test_migrations.py
+++ b/tests/integration/persistence/test_migrations.py
@@ -77,6 +77,21 @@ def test_alembic_head_creates_canonical_runtime_schema(postgres_engine: Engine) 
     created_at_type = signal_columns["created_at"]["type"]
     assert isinstance(created_at_type, sa.DateTime)
     assert created_at_type.timezone is True
+    outcome_columns = {
+        column["name"]: column for column in inspector.get_columns("position_open_outcomes")
+    }
+    assert {"signal_id", "decided_at"} <= set(outcome_columns)
+    decided_at_type = outcome_columns["decided_at"]["type"]
+    assert isinstance(decided_at_type, sa.DateTime)
+    assert decided_at_type.timezone is True
+    outcome_fks = {
+        constraint["name"]: constraint
+        for constraint in inspector.get_foreign_keys("position_open_outcomes")
+    }
+    assert (
+        outcome_fks["fk_position_open_outcomes_fill_id_fills"]["options"]["ondelete"] == "RESTRICT"
+    )
+    assert outcome_fks["fk_position_open_outcomes_signal_id_signals"]["referred_table"] == "signals"
 
 
 def test_schema_enforces_core_lifecycle_constraints(postgres_engine: Engine) -> None:

--- a/tests/integration/persistence/test_repository_adapters_postgres.py
+++ b/tests/integration/persistence/test_repository_adapters_postgres.py
@@ -17,7 +17,7 @@ from signalforge.domain.armed import ArmedSetup, ArmedSetupState, ExpiryReason
 from signalforge.domain.audit import StateTransition, TransitionEntityType
 from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, TriggerEvent
 from signalforge.domain.exits import Exit, ExitReason
-from signalforge.domain.ids import ConfigId, FillId, InstrumentId, RunId
+from signalforge.domain.ids import ConfigId, FillId, InstrumentId, RunId, SignalId
 from signalforge.domain.money import Price, Quantity
 from signalforge.domain.position_outcomes import PositionOpenOutcome, PositionOpenOutcomeType
 from signalforge.domain.positions import Position, PositionState
@@ -431,7 +431,11 @@ def test_coordinator_opened_entry_boundary_rolls_back_each_write(
     value = facts(f"sf046-open-{after}-{uuid4().hex}", at=AT + timedelta(days=130 + after))
     _commit_trigger_intent(postgres_engine, value)
     outcome = PositionOpenOutcome.create(
-        fill_id=value.fill.fill_id, outcome=PositionOpenOutcomeType.OPENED, run=value.run
+        fill_id=value.fill.fill_id,
+        signal_id=value.fill.signal_id,
+        outcome=PositionOpenOutcomeType.OPENED,
+        decided_at=value.fill.filled_at,
+        run=value.run,
     )
     trade_transition = _transition(
         value,
@@ -497,6 +501,8 @@ def test_coordinator_rejected_entry_boundary_rolls_back_each_write(
     _commit_trigger_intent(postgres_engine, value)
     outcome = PositionOpenOutcome.create(
         fill_id=value.fill.fill_id,
+        signal_id=value.fill.signal_id,
+        decided_at=value.fill.filled_at,
         outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
         run=value.run,
     )
@@ -826,6 +832,8 @@ def test_position_open_outcome_is_exactly_one_idempotent_fact_per_fill(session: 
     repository = PostgresPositionOpenOutcomeRepository(session)
     opened = PositionOpenOutcome.create(
         fill_id=value.fill.fill_id,
+        signal_id=value.fill.signal_id,
+        decided_at=value.fill.filled_at,
         outcome=PositionOpenOutcomeType.OPENED,
         run=value.run,
     )
@@ -835,6 +843,8 @@ def test_position_open_outcome_is_exactly_one_idempotent_fact_per_fill(session: 
 
     rejected = PositionOpenOutcome.create(
         fill_id=value.fill.fill_id,
+        signal_id=value.fill.signal_id,
+        decided_at=value.fill.filled_at,
         outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
         run=value.run,
     )
@@ -842,16 +852,55 @@ def test_position_open_outcome_is_exactly_one_idempotent_fact_per_fill(session: 
         repository.append(rejected)
     assert opened.outcome_id == rejected.outcome_id
     assert repository.get(opened.outcome_id) == opened
+    stored_opened = repository.get(opened.outcome_id)
+    assert stored_opened is not None
+    assert stored_opened.signal_id == value.fill.signal_id
+    assert stored_opened.decided_at == value.fill.filled_at
+    assert stored_opened.decided_at.tzinfo is not None
+
+    missing_signal = PositionOpenOutcome.create(
+        fill_id=value.fill.fill_id,
+        signal_id=SignalId("sf046-missing-signal"),
+        decided_at=value.fill.filled_at,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=value.run,
+    )
+    with pytest.raises(PersistenceDependencyError):
+        repository.append(missing_signal)
+
+    other_interval = CandleInterval.five_minutes(value.signal.created_at + timedelta(minutes=5))
+    other_signal = Signal.create(
+        instrument_id=value.signal.instrument_id,
+        interval=other_interval,
+        signal_close=value.signal.signal_close,
+        signal_low=value.signal.signal_low,
+        run=value.run,
+        created_at=other_interval.end,
+    )
+    assert PostgresSignalRepository(session).append(other_signal) == other_signal
+    mismatched_signal = PositionOpenOutcome.create(
+        fill_id=value.fill.fill_id,
+        signal_id=other_signal.signal_id,
+        decided_at=value.fill.filled_at,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=value.run,
+    )
+    with pytest.raises(ContradictoryFactError):
+        repository.append(mismatched_signal)
 
     reverse = facts("position-open-outcome-reverse", at=AT + timedelta(hours=14))
     persist_graph(session, reverse)
     reverse_rejected = PositionOpenOutcome.create(
         fill_id=reverse.fill.fill_id,
+        signal_id=reverse.fill.signal_id,
+        decided_at=reverse.fill.filled_at,
         outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
         run=reverse.run,
     )
     reverse_opened = PositionOpenOutcome.create(
         fill_id=reverse.fill.fill_id,
+        signal_id=reverse.fill.signal_id,
+        decided_at=reverse.fill.filled_at,
         outcome=PositionOpenOutcomeType.OPENED,
         run=reverse.run,
     )
@@ -864,6 +913,8 @@ def test_position_open_outcome_is_exactly_one_idempotent_fact_per_fill(session: 
     missing_fill = facts("position-open-outcome-missing-fill", at=AT + timedelta(hours=15))
     missing_outcome = PositionOpenOutcome.create(
         fill_id=missing_fill.fill.fill_id,
+        signal_id=missing_fill.fill.signal_id,
+        decided_at=missing_fill.fill.filled_at,
         outcome=PositionOpenOutcomeType.OPENED,
         run=missing_fill.run,
     )
@@ -1103,11 +1154,14 @@ def test_coordinator_exact_and_committed_retries_for_all_boundaries(
             )
             is not None
         )
-
     opened = facts(f"retry-open-{uuid4().hex}", at=AT + timedelta(days=303))
     _commit_trigger_intent(postgres_engine, opened)
     opened_outcome = PositionOpenOutcome.create(
-        fill_id=opened.fill.fill_id, outcome=PositionOpenOutcomeType.OPENED, run=opened.run
+        fill_id=opened.fill.fill_id,
+        signal_id=opened.fill.signal_id,
+        outcome=PositionOpenOutcomeType.OPENED,
+        decided_at=opened.fill.filled_at,
+        run=opened.run,
     )
     trade_open = _transition(
         opened,
@@ -1177,6 +1231,8 @@ def test_coordinator_exact_and_committed_retries_for_all_boundaries(
     _commit_trigger_intent(postgres_engine, rejected)
     rejected_outcome = PositionOpenOutcome.create(
         fill_id=rejected.fill.fill_id,
+        signal_id=rejected.fill.signal_id,
+        decided_at=rejected.fill.filled_at,
         outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
         run=rejected.run,
     )
@@ -1361,6 +1417,8 @@ def test_coordinator_opened_entry_classifies_partial_graphs_explicitly(
     _commit_trigger_intent(postgres_engine, exact)
     exact_outcome = PositionOpenOutcome.create(
         fill_id=exact.fill.fill_id,
+        signal_id=exact.fill.signal_id,
+        decided_at=exact.fill.filled_at,
         outcome=PositionOpenOutcomeType.OPENED,
         run=exact.run,
     )
@@ -1404,11 +1462,15 @@ def test_coordinator_opened_entry_classifies_partial_graphs_explicitly(
     _commit_trigger_intent(postgres_engine, conflicting)
     rejected = PositionOpenOutcome.create(
         fill_id=conflicting.fill.fill_id,
+        signal_id=conflicting.fill.signal_id,
+        decided_at=conflicting.fill.filled_at,
         outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
         run=conflicting.run,
     )
     conflicting_opened = PositionOpenOutcome.create(
         fill_id=conflicting.fill.fill_id,
+        signal_id=conflicting.fill.signal_id,
+        decided_at=conflicting.fill.filled_at,
         outcome=PositionOpenOutcomeType.OPENED,
         run=conflicting.run,
     )

--- a/tests/integration/persistence/test_repository_adapters_postgres.py
+++ b/tests/integration/persistence/test_repository_adapters_postgres.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from decimal import Decimal
+from uuid import uuid4
 
 import pytest
 import sqlalchemy as sa
@@ -288,7 +289,7 @@ def test_coordinator_arming_boundary_rolls_back_each_write(
     monkeypatch: pytest.MonkeyPatch,
     after: int,
 ) -> None:
-    value = facts(f"sf046-arm-{after}", at=AT + timedelta(days=after))
+    value = facts(f"sf046-arm-{after}-{uuid4().hex}", at=AT + timedelta(days=after))
     transition = _transition(
         value,
         entity=TransitionEntityType.ARMED_SETUP,
@@ -338,7 +339,7 @@ def _commit_armed_setup(postgres_engine: Engine, value: Facts) -> None:
 def test_coordinator_trigger_boundary_rolls_back_each_write(
     postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
 ) -> None:
-    value = facts(f"sf046-trigger-{after}", at=AT + timedelta(days=10 + after))
+    value = facts(f"sf046-trigger-{after}-{uuid4().hex}", at=AT + timedelta(days=10 + after))
     _commit_armed_setup(postgres_engine, value)
     triggered = replace(value.setup)
     triggered.trigger(at=value.trigger.observed_at)
@@ -382,7 +383,7 @@ def test_coordinator_trigger_boundary_rolls_back_each_write(
 def test_coordinator_expiry_boundary_rolls_back_each_write(
     postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
 ) -> None:
-    value = facts(f"sf046-expiry-{after}", at=AT + timedelta(days=20 + after))
+    value = facts(f"sf046-expiry-{after}-{uuid4().hex}", at=AT + timedelta(days=20 + after))
     _commit_armed_setup(postgres_engine, value)
     expired = replace(value.setup)
     expired.expire(at=expired.valid_until, reason=ExpiryReason.VALIDITY_WINDOW_END)
@@ -427,7 +428,7 @@ def _commit_trigger_intent(postgres_engine: Engine, value: Facts) -> None:
 def test_coordinator_opened_entry_boundary_rolls_back_each_write(
     postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
 ) -> None:
-    value = facts(f"sf046-open-v2-{after}", at=AT + timedelta(days=130 + after))
+    value = facts(f"sf046-open-{after}-{uuid4().hex}", at=AT + timedelta(days=130 + after))
     _commit_trigger_intent(postgres_engine, value)
     outcome = PositionOpenOutcome.create(
         fill_id=value.fill.fill_id, outcome=PositionOpenOutcomeType.OPENED, run=value.run
@@ -492,7 +493,7 @@ def test_coordinator_opened_entry_boundary_rolls_back_each_write(
 def test_coordinator_rejected_entry_boundary_rolls_back_each_write(
     postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
 ) -> None:
-    value = facts(f"sf046-reject-v2-{after}", at=AT + timedelta(days=140 + after))
+    value = facts(f"sf046-reject-{after}-{uuid4().hex}", at=AT + timedelta(days=140 + after))
     _commit_trigger_intent(postgres_engine, value)
     outcome = PositionOpenOutcome.create(
         fill_id=value.fill.fill_id,
@@ -527,7 +528,7 @@ def _commit_open_position(postgres_engine: Engine, value: Facts) -> None:
 def test_coordinator_exit_boundary_rolls_back_each_write(
     postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
 ) -> None:
-    value = facts(f"sf046-exit-v2-{after}", at=AT + timedelta(days=150 + after))
+    value = facts(f"sf046-exit-{after}-{uuid4().hex}", at=AT + timedelta(days=150 + after))
     _commit_open_position(postgres_engine, value)
     closed_trade = replace(value.trade)
     closed_trade.close(exit_id=value.exit_fact.exit_id, at=value.exit_fact.exited_at)

--- a/tests/integration/persistence/test_repository_adapters_postgres.py
+++ b/tests/integration/persistence/test_repository_adapters_postgres.py
@@ -840,6 +840,35 @@ def test_position_open_outcome_is_exactly_one_idempotent_fact_per_fill(session: 
     )
     with pytest.raises(ContradictoryFactError):
         repository.append(rejected)
+    assert opened.outcome_id == rejected.outcome_id
+    assert repository.get(opened.outcome_id) == opened
+
+    reverse = facts("position-open-outcome-reverse", at=AT + timedelta(hours=14))
+    persist_graph(session, reverse)
+    reverse_rejected = PositionOpenOutcome.create(
+        fill_id=reverse.fill.fill_id,
+        outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
+        run=reverse.run,
+    )
+    reverse_opened = PositionOpenOutcome.create(
+        fill_id=reverse.fill.fill_id,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=reverse.run,
+    )
+    assert reverse_rejected.outcome_id == reverse_opened.outcome_id
+    assert repository.append(reverse_rejected) == reverse_rejected
+    with pytest.raises(ContradictoryFactError):
+        repository.append(reverse_opened)
+    assert repository.get(reverse_rejected.outcome_id) == reverse_rejected
+
+    missing_fill = facts("position-open-outcome-missing-fill", at=AT + timedelta(hours=15))
+    missing_outcome = PositionOpenOutcome.create(
+        fill_id=missing_fill.fill.fill_id,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=missing_fill.run,
+    )
+    with pytest.raises(PersistenceDependencyError):
+        repository.append(missing_outcome)
 
 
 def test_authoritative_repositories_reject_conflicts_and_keep_outer_transaction_usable(
@@ -936,3 +965,495 @@ def test_authoritative_repositories_require_persisted_dependencies(session: Sess
         PostgresTradeRepository(session).upsert(value.trade)
     with pytest.raises(PersistenceDependencyError):
         PostgresPositionRepository(session).upsert(value.position)
+
+
+def test_coordinator_exact_and_committed_retries_for_all_boundaries(
+    postgres_engine: Engine,
+) -> None:
+    """Coordinator retries preserve deterministic rows for all accepted cases."""
+    arm = facts(f"retry-arm-{uuid4().hex}", at=AT + timedelta(days=300))
+    arm_transition = _transition(
+        arm,
+        entity=TransitionEntityType.ARMED_SETUP,
+        entity_id=str(arm.signal.signal_id),
+        before="none",
+        after="armed",
+        cause_type="strategy_evaluation",
+        cause_id="evaluation",
+        occurred_at=arm.setup.armed_at,
+    )
+    with Session(postgres_engine) as session:
+        PostgresRunProvenanceRepository(session).add(arm.run)
+        session.commit()
+        coordinator = PersistenceCoordinator(session)
+        first = coordinator.persist_actionable_evaluation(
+            evaluation=arm.evaluation,
+            signal=arm.signal,
+            setup=arm.setup,
+            setup_transition=arm_transition,
+        )
+        assert first[0] == arm.evaluation
+        assert first[1] == arm.signal
+        assert first[2].signal_id == arm.setup.signal_id
+        assert first[2].state is ArmedSetupState.ARMED
+        assert first[2].armed_at == arm.setup.armed_at
+        assert first[3].transition_id == arm_transition.transition_id
+        assert (
+            coordinator.persist_actionable_evaluation(
+                evaluation=arm.evaluation,
+                signal=arm.signal,
+                setup=arm.setup,
+                setup_transition=arm_transition,
+            )
+            is not None
+        )
+    with Session(postgres_engine) as session:
+        assert (
+            PersistenceCoordinator(session).persist_actionable_evaluation(
+                evaluation=arm.evaluation,
+                signal=arm.signal,
+                setup=arm.setup,
+                setup_transition=arm_transition,
+            )
+            is not None
+        )
+
+    trigger = facts(f"retry-trigger-{uuid4().hex}", at=AT + timedelta(days=301))
+    _commit_armed_setup(postgres_engine, trigger)
+    triggered = replace(trigger.setup)
+    triggered.trigger(at=trigger.trigger.observed_at)
+    trigger_transition = _transition(
+        trigger,
+        entity=TransitionEntityType.ARMED_SETUP,
+        entity_id=str(trigger.signal.signal_id),
+        before="armed",
+        after="triggered",
+        cause_type="trigger_event",
+        cause_id=str(trigger.trigger.trigger_event_id),
+        occurred_at=trigger.trigger.observed_at,
+    )
+    with Session(postgres_engine) as session:
+        coordinator = PersistenceCoordinator(session)
+        first = coordinator.persist_trigger_intent(
+            trigger=trigger.trigger,
+            intent=trigger.intent,
+            setup=triggered,
+            setup_transition=trigger_transition,
+        )
+        assert first[0] == trigger.trigger
+        assert first[1] == trigger.intent
+        assert first[2].signal_id == trigger.setup.signal_id
+        assert first[2].state is ArmedSetupState.TRIGGERED
+        assert first[2].terminal_at == triggered.terminal_at
+        assert first[3].transition_id == trigger_transition.transition_id
+        assert (
+            coordinator.persist_trigger_intent(
+                trigger=trigger.trigger,
+                intent=trigger.intent,
+                setup=triggered,
+                setup_transition=trigger_transition,
+            )
+            is not None
+        )
+    with Session(postgres_engine) as session:
+        assert (
+            PersistenceCoordinator(session).persist_trigger_intent(
+                trigger=trigger.trigger,
+                intent=trigger.intent,
+                setup=triggered,
+                setup_transition=trigger_transition,
+            )
+            is not None
+        )
+
+    expired = facts(f"retry-expiry-{uuid4().hex}", at=AT + timedelta(days=302))
+    _commit_armed_setup(postgres_engine, expired)
+    expired_setup = replace(expired.setup)
+    expired_setup.expire(at=expired_setup.valid_until, reason=ExpiryReason.VALIDITY_WINDOW_END)
+    expiry_transition = _transition(
+        expired,
+        entity=TransitionEntityType.ARMED_SETUP,
+        entity_id=str(expired.signal.signal_id),
+        before="armed",
+        after="expired",
+        cause_type="completed_candle",
+        cause_id="candle",
+        occurred_at=expired_setup.valid_until,
+    )
+    with Session(postgres_engine) as session:
+        coordinator = PersistenceCoordinator(session)
+        first = coordinator.persist_expiry(
+            run_id=expired.run.run_id, setup=expired_setup, setup_transition=expiry_transition
+        )
+        assert first[0].signal_id == expired.setup.signal_id
+        assert first[0].state is ArmedSetupState.EXPIRED
+        assert first[0].terminal_at == expired_setup.terminal_at
+        assert first[0].expiry_reason is ExpiryReason.VALIDITY_WINDOW_END
+        assert first[1].transition_id == expiry_transition.transition_id
+        assert (
+            coordinator.persist_expiry(
+                run_id=expired.run.run_id, setup=expired_setup, setup_transition=expiry_transition
+            )
+            is not None
+        )
+    with Session(postgres_engine) as session:
+        assert (
+            PersistenceCoordinator(session).persist_expiry(
+                run_id=expired.run.run_id, setup=expired_setup, setup_transition=expiry_transition
+            )
+            is not None
+        )
+
+    opened = facts(f"retry-open-{uuid4().hex}", at=AT + timedelta(days=303))
+    _commit_trigger_intent(postgres_engine, opened)
+    opened_outcome = PositionOpenOutcome.create(
+        fill_id=opened.fill.fill_id, outcome=PositionOpenOutcomeType.OPENED, run=opened.run
+    )
+    trade_open = _transition(
+        opened,
+        entity=TransitionEntityType.TRADE,
+        entity_id=str(opened.trade.trade_id),
+        before="none",
+        after="open",
+        cause_type="fill",
+        cause_id=str(opened.fill.fill_id),
+        occurred_at=opened.trade.opened_at,
+    )
+    position_open = _transition(
+        opened,
+        entity=TransitionEntityType.POSITION,
+        entity_id=str(opened.position.position_id),
+        before="none",
+        after="open",
+        cause_type="trade",
+        cause_id=str(opened.trade.trade_id),
+        occurred_at=opened.position.opened_at,
+    )
+    with Session(postgres_engine) as session:
+        coordinator = PersistenceCoordinator(session)
+        first = coordinator.persist_opened_entry(
+            fill=opened.fill,
+            outcome=opened_outcome,
+            trade=opened.trade,
+            position=opened.position,
+            trade_transition=trade_open,
+            position_transition=position_open,
+        )
+        assert first[0] == opened.fill
+        assert first[1] == opened_outcome
+        assert first[2].trade_id == opened.trade.trade_id
+        assert first[2].state is TradeState.OPEN
+        assert first[2].opened_at == opened.trade.opened_at
+        assert first[3].position_id == opened.position.position_id
+        assert first[3].state is PositionState.OPEN
+        assert first[3].opened_at == opened.position.opened_at
+        assert first[4].transition_id == trade_open.transition_id
+        assert first[5].transition_id == position_open.transition_id
+        assert (
+            coordinator.persist_opened_entry(
+                fill=opened.fill,
+                outcome=opened_outcome,
+                trade=opened.trade,
+                position=opened.position,
+                trade_transition=trade_open,
+                position_transition=position_open,
+            )
+            is not None
+        )
+    with Session(postgres_engine) as session:
+        assert (
+            PersistenceCoordinator(session).persist_opened_entry(
+                fill=opened.fill,
+                outcome=opened_outcome,
+                trade=opened.trade,
+                position=opened.position,
+                trade_transition=trade_open,
+                position_transition=position_open,
+            )
+            is not None
+        )
+
+    rejected = facts(f"retry-reject-{uuid4().hex}", at=AT + timedelta(days=304))
+    _commit_trigger_intent(postgres_engine, rejected)
+    rejected_outcome = PositionOpenOutcome.create(
+        fill_id=rejected.fill.fill_id,
+        outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
+        run=rejected.run,
+    )
+    with Session(postgres_engine) as session:
+        coordinator = PersistenceCoordinator(session)
+        first = coordinator.persist_rejected_entry(fill=rejected.fill, outcome=rejected_outcome)
+        assert first[0] == rejected.fill
+        assert first[1] == rejected_outcome
+        assert (
+            coordinator.persist_rejected_entry(fill=rejected.fill, outcome=rejected_outcome)
+            is not None
+        )
+    with Session(postgres_engine) as session:
+        assert (
+            PersistenceCoordinator(session).persist_rejected_entry(
+                fill=rejected.fill, outcome=rejected_outcome
+            )
+            is not None
+        )
+
+    exiting = facts(f"retry-exit-{uuid4().hex}", at=AT + timedelta(days=305))
+    _commit_open_position(postgres_engine, exiting)
+    closed_trade = replace(exiting.trade)
+    closed_trade.close(exit_id=exiting.exit_fact.exit_id, at=exiting.exit_fact.exited_at)
+    closed_position = replace(exiting.position)
+    closed_position.close(at=exiting.exit_fact.exited_at)
+    trade_close = _transition(
+        exiting,
+        entity=TransitionEntityType.TRADE,
+        entity_id=str(exiting.trade.trade_id),
+        before="open",
+        after="closed",
+        cause_type="exit",
+        cause_id=str(exiting.exit_fact.exit_id),
+        occurred_at=exiting.exit_fact.exited_at,
+    )
+    position_close = _transition(
+        exiting,
+        entity=TransitionEntityType.POSITION,
+        entity_id=str(exiting.position.position_id),
+        before="open",
+        after="closed",
+        cause_type="exit",
+        cause_id=str(exiting.exit_fact.exit_id),
+        occurred_at=exiting.exit_fact.exited_at,
+    )
+    with Session(postgres_engine) as session:
+        coordinator = PersistenceCoordinator(session)
+        first = coordinator.persist_exit(
+            exit_fact=exiting.exit_fact,
+            trade=closed_trade,
+            position=closed_position,
+            trade_transition=trade_close,
+            position_transition=position_close,
+        )
+        assert first[0] == exiting.exit_fact
+        assert first[1].trade_id == exiting.trade.trade_id
+        assert first[1].state is TradeState.CLOSED
+        assert first[1].closed_at == exiting.exit_fact.exited_at
+        assert first[1].exit_id == exiting.exit_fact.exit_id
+        assert first[2].position_id == exiting.position.position_id
+        assert first[2].state is PositionState.CLOSED
+        assert first[2].closed_at == exiting.exit_fact.exited_at
+        assert first[3].transition_id == trade_close.transition_id
+        assert first[4].transition_id == position_close.transition_id
+        assert (
+            coordinator.persist_exit(
+                exit_fact=exiting.exit_fact,
+                trade=closed_trade,
+                position=closed_position,
+                trade_transition=trade_close,
+                position_transition=position_close,
+            )
+            is not None
+        )
+    with Session(postgres_engine) as session:
+        assert (
+            PersistenceCoordinator(session).persist_exit(
+                exit_fact=exiting.exit_fact,
+                trade=closed_trade,
+                position=closed_position,
+                trade_transition=trade_close,
+                position_transition=position_close,
+            )
+            is not None
+        )
+
+    # A separate Session sees the same deterministic logical identities and no
+    # different terminal/current state after each committed retry.
+    with Session(postgres_engine) as observer:
+        stored_arm = PostgresArmedSetupRepository(observer).get(arm.setup.signal_id)
+        assert stored_arm is not None
+        assert stored_arm.state is ArmedSetupState.ARMED
+        assert stored_arm.armed_at == arm.setup.armed_at
+        assert (
+            PostgresStateTransitionRepository(observer).get(arm_transition.transition_id)
+            == arm_transition
+        )
+
+        stored_trigger = PostgresArmedSetupRepository(observer).get(trigger.setup.signal_id)
+        assert stored_trigger is not None
+        assert stored_trigger.state is ArmedSetupState.TRIGGERED
+        assert stored_trigger.terminal_at == triggered.terminal_at
+        assert (
+            PostgresTriggerEventRepository(observer).get(trigger.trigger.trigger_event_id)
+            == trigger.trigger
+        )
+        assert (
+            PostgresEntryIntentRepository(observer).get(trigger.intent.entry_intent_id)
+            == trigger.intent
+        )
+        assert (
+            PostgresStateTransitionRepository(observer).get(trigger_transition.transition_id)
+            == trigger_transition
+        )
+
+        stored_expiry = PostgresArmedSetupRepository(observer).get(expired.setup.signal_id)
+        assert stored_expiry is not None
+        assert stored_expiry.state is ArmedSetupState.EXPIRED
+        assert stored_expiry.terminal_at == expired_setup.terminal_at
+        assert stored_expiry.expiry_reason is ExpiryReason.VALIDITY_WINDOW_END
+        assert (
+            PostgresStateTransitionRepository(observer).get(expiry_transition.transition_id)
+            == expiry_transition
+        )
+
+        stored_trade = PostgresTradeRepository(observer).get(opened.trade.trade_id)
+        stored_position = PostgresPositionRepository(observer).get(opened.position.position_id)
+        assert stored_trade is not None and stored_trade.state is TradeState.OPEN
+        assert stored_position is not None and stored_position.state is PositionState.OPEN
+        assert stored_trade.opened_at == opened.trade.opened_at
+        assert stored_position.opened_at == opened.position.opened_at
+        assert PostgresFillRepository(observer).get(opened.fill.fill_id) == opened.fill
+        assert (
+            PostgresPositionOpenOutcomeRepository(observer).get(opened_outcome.outcome_id)
+            == opened_outcome
+        )
+        assert (
+            PostgresStateTransitionRepository(observer).get(trade_open.transition_id) == trade_open
+        )
+        assert (
+            PostgresStateTransitionRepository(observer).get(position_open.transition_id)
+            == position_open
+        )
+
+        assert PostgresFillRepository(observer).get(rejected.fill.fill_id) == rejected.fill
+        assert (
+            PostgresPositionOpenOutcomeRepository(observer).get(rejected_outcome.outcome_id)
+            == rejected_outcome
+        )
+        assert PostgresTradeRepository(observer).get(rejected.trade.trade_id) is None
+        assert PostgresPositionRepository(observer).get(rejected.position.position_id) is None
+
+        stored_closed_trade = PostgresTradeRepository(observer).get(exiting.trade.trade_id)
+        stored_closed_position = PostgresPositionRepository(observer).get(
+            exiting.position.position_id
+        )
+        assert stored_closed_trade is not None and stored_closed_trade.state is TradeState.CLOSED
+        assert (
+            stored_closed_position is not None
+            and stored_closed_position.state is PositionState.CLOSED
+        )
+        assert stored_closed_trade.closed_at == exiting.exit_fact.exited_at
+        assert stored_closed_trade.exit_id == exiting.exit_fact.exit_id
+        assert stored_closed_position.closed_at == exiting.exit_fact.exited_at
+        assert PostgresExitRepository(observer).get(exiting.exit_fact.exit_id) == exiting.exit_fact
+        assert (
+            PostgresStateTransitionRepository(observer).get(trade_close.transition_id)
+            == trade_close
+        )
+        assert (
+            PostgresStateTransitionRepository(observer).get(position_close.transition_id)
+            == position_close
+        )
+
+
+def test_coordinator_opened_entry_classifies_partial_graphs_explicitly(
+    postgres_engine: Engine,
+) -> None:
+    """Exact Fill-only partials complete; conflicting outcome partials do not."""
+    exact = facts(f"partial-exact-{uuid4().hex}", at=AT + timedelta(days=306))
+    _commit_trigger_intent(postgres_engine, exact)
+    exact_outcome = PositionOpenOutcome.create(
+        fill_id=exact.fill.fill_id,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=exact.run,
+    )
+    exact_trade_transition = _transition(
+        exact,
+        entity=TransitionEntityType.TRADE,
+        entity_id=str(exact.trade.trade_id),
+        before="none",
+        after="open",
+        cause_type="fill",
+        cause_id=str(exact.fill.fill_id),
+        occurred_at=exact.trade.opened_at,
+    )
+    exact_position_transition = _transition(
+        exact,
+        entity=TransitionEntityType.POSITION,
+        entity_id=str(exact.position.position_id),
+        before="none",
+        after="open",
+        cause_type="trade",
+        cause_id=str(exact.trade.trade_id),
+        occurred_at=exact.position.opened_at,
+    )
+    with Session(postgres_engine) as session:
+        assert PostgresFillRepository(session).append(exact.fill) == exact.fill
+        session.commit()
+    with Session(postgres_engine) as session:
+        persisted = PersistenceCoordinator(session).persist_opened_entry(
+            fill=exact.fill,
+            outcome=exact_outcome,
+            trade=exact.trade,
+            position=exact.position,
+            trade_transition=exact_trade_transition,
+            position_transition=exact_position_transition,
+        )
+        assert persisted[1] == exact_outcome
+        assert persisted[2].trade_id == exact.trade.trade_id
+        assert persisted[3].position_id == exact.position.position_id
+
+    conflicting = facts(f"partial-conflict-{uuid4().hex}", at=AT + timedelta(days=307))
+    _commit_trigger_intent(postgres_engine, conflicting)
+    rejected = PositionOpenOutcome.create(
+        fill_id=conflicting.fill.fill_id,
+        outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
+        run=conflicting.run,
+    )
+    conflicting_opened = PositionOpenOutcome.create(
+        fill_id=conflicting.fill.fill_id,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=conflicting.run,
+    )
+    trade_transition = _transition(
+        conflicting,
+        entity=TransitionEntityType.TRADE,
+        entity_id=str(conflicting.trade.trade_id),
+        before="none",
+        after="open",
+        cause_type="fill",
+        cause_id=str(conflicting.fill.fill_id),
+        occurred_at=conflicting.trade.opened_at,
+    )
+    position_transition = _transition(
+        conflicting,
+        entity=TransitionEntityType.POSITION,
+        entity_id=str(conflicting.position.position_id),
+        before="none",
+        after="open",
+        cause_type="trade",
+        cause_id=str(conflicting.trade.trade_id),
+        occurred_at=conflicting.position.opened_at,
+    )
+    with Session(postgres_engine) as session:
+        PostgresFillRepository(session).append(conflicting.fill)
+        PostgresPositionOpenOutcomeRepository(session).append(rejected)
+        session.commit()
+    with Session(postgres_engine) as session:
+        with pytest.raises(ContradictoryFactError):
+            PersistenceCoordinator(session).persist_opened_entry(
+                fill=conflicting.fill,
+                outcome=conflicting_opened,
+                trade=conflicting.trade,
+                position=conflicting.position,
+                trade_transition=trade_transition,
+                position_transition=position_transition,
+            )
+    with Session(postgres_engine) as observer:
+        assert PostgresPositionOpenOutcomeRepository(observer).get(rejected.outcome_id) == rejected
+        assert PostgresTradeRepository(observer).get(conflicting.trade.trade_id) is None
+        assert PostgresPositionRepository(observer).get(conflicting.position.position_id) is None
+        assert (
+            PostgresStateTransitionRepository(observer).get(trade_transition.transition_id) is None
+        )
+        assert (
+            PostgresStateTransitionRepository(observer).get(position_transition.transition_id)
+            is None
+        )

--- a/tests/integration/persistence/test_repository_adapters_postgres.py
+++ b/tests/integration/persistence/test_repository_adapters_postgres.py
@@ -11,6 +11,7 @@ import sqlalchemy as sa
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
+import signalforge.persistence.coordinator as coordinator_module
 from signalforge.domain.armed import ArmedSetup, ArmedSetupState, ExpiryReason
 from signalforge.domain.audit import StateTransition, TransitionEntityType
 from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, TriggerEvent
@@ -30,6 +31,7 @@ from signalforge.domain.strategy import (
 )
 from signalforge.domain.time import IST, CandleInterval
 from signalforge.domain.trades import Trade, TradeState
+from signalforge.persistence.coordinator import PersistenceCoordinator
 from signalforge.persistence.errors import ContradictoryFactError, PersistenceDependencyError
 from signalforge.persistence.models import RunRecord, StrategyConfigRecord
 from signalforge.persistence.repositories import (
@@ -49,6 +51,10 @@ from signalforge.persistence.repositories import (
 
 AT = datetime(2026, 9, 1, 10, 0, tzinfo=IST)
 INSTRUMENT = InstrumentId("NSE:SF045B")
+
+
+class InjectedFailure(RuntimeError):
+    pass
 
 
 @pytest.fixture(scope="module")
@@ -212,6 +218,374 @@ def persist_graph(session: Session, value: Facts) -> None:
     assert PostgresPositionRepository(session).upsert(value.position).state is PositionState.OPEN
     assert PostgresExitRepository(session).append(value.exit_fact) == value.exit_fact
     assert PostgresStateTransitionRepository(session).append(value.transition) == value.transition
+
+
+def _transition(
+    value: Facts,
+    *,
+    entity: TransitionEntityType,
+    entity_id: str,
+    before: str,
+    after: str,
+    cause_type: str,
+    cause_id: str,
+    occurred_at: datetime,
+) -> StateTransition:
+    return StateTransition.create(
+        entity_type=entity,
+        entity_id=entity_id,
+        from_state=before,
+        to_state=after,
+        cause_type=cause_type,
+        cause_id=cause_id,
+        occurred_at=occurred_at,
+        run=value.run,
+    )
+
+
+def _inject_after(monkeypatch: pytest.MonkeyPatch, *, after: int, names: tuple[str, ...]) -> None:
+    count = 0
+    for name in names:
+        repository = getattr(coordinator_module, name)
+        original = (
+            repository.append
+            if name
+            not in {
+                "PostgresArmedSetupRepository",
+                "PostgresTradeRepository",
+                "PostgresPositionRepository",
+            }
+            else repository.upsert
+        )
+
+        def wrapped(
+            self: object, *args: object, _original: object = original, **kwargs: object
+        ) -> object:
+            nonlocal count
+            result = _original(self, *args, **kwargs)  # type: ignore[operator]
+            count += 1
+            if count == after:
+                raise InjectedFailure
+            return result
+
+        monkeypatch.setattr(
+            repository,
+            "append"
+            if name
+            not in {
+                "PostgresArmedSetupRepository",
+                "PostgresTradeRepository",
+                "PostgresPositionRepository",
+            }
+            else "upsert",
+            wrapped,
+        )
+
+
+@pytest.mark.parametrize("after", (1, 2, 3, 4))
+def test_coordinator_arming_boundary_rolls_back_each_write(
+    postgres_engine: Engine,
+    monkeypatch: pytest.MonkeyPatch,
+    after: int,
+) -> None:
+    value = facts(f"sf046-arm-{after}", at=AT + timedelta(days=after))
+    transition = _transition(
+        value,
+        entity=TransitionEntityType.ARMED_SETUP,
+        entity_id=str(value.signal.signal_id),
+        before="none",
+        after="armed",
+        cause_type="strategy_evaluation",
+        cause_id="evaluation",
+        occurred_at=value.setup.armed_at,
+    )
+    with Session(postgres_engine) as setup_session:
+        PostgresRunProvenanceRepository(setup_session).add(value.run)
+        setup_session.commit()
+    _inject_after(
+        monkeypatch,
+        after=after,
+        names=(
+            "PostgresStrategyEvaluationRepository",
+            "PostgresSignalRepository",
+            "PostgresArmedSetupRepository",
+            "PostgresStateTransitionRepository",
+        ),
+    )
+    with Session(postgres_engine) as session:
+        with pytest.raises(InjectedFailure):
+            PersistenceCoordinator(session).persist_actionable_evaluation(
+                evaluation=value.evaluation,
+                signal=value.signal,
+                setup=value.setup,
+                setup_transition=transition,
+            )
+    with Session(postgres_engine) as observer:
+        assert PostgresSignalRepository(observer).get(value.signal.signal_id) is None
+        assert PostgresArmedSetupRepository(observer).get(value.signal.signal_id) is None
+        assert PostgresStateTransitionRepository(observer).get(transition.transition_id) is None
+
+
+def _commit_armed_setup(postgres_engine: Engine, value: Facts) -> None:
+    with Session(postgres_engine) as session:
+        PostgresRunProvenanceRepository(session).add(value.run)
+        PostgresSignalRepository(session).append(value.signal)
+        PostgresArmedSetupRepository(session).upsert(value.run.run_id, value.setup)
+        session.commit()
+
+
+@pytest.mark.parametrize("after", (1, 2, 3, 4))
+def test_coordinator_trigger_boundary_rolls_back_each_write(
+    postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
+) -> None:
+    value = facts(f"sf046-trigger-{after}", at=AT + timedelta(days=10 + after))
+    _commit_armed_setup(postgres_engine, value)
+    triggered = replace(value.setup)
+    triggered.trigger(at=value.trigger.observed_at)
+    transition = _transition(
+        value,
+        entity=TransitionEntityType.ARMED_SETUP,
+        entity_id=str(value.signal.signal_id),
+        before="armed",
+        after="triggered",
+        cause_type="trigger_event",
+        cause_id=str(value.trigger.trigger_event_id),
+        occurred_at=value.trigger.observed_at,
+    )
+    _inject_after(
+        monkeypatch,
+        after=after,
+        names=(
+            "PostgresTriggerEventRepository",
+            "PostgresEntryIntentRepository",
+            "PostgresArmedSetupRepository",
+            "PostgresStateTransitionRepository",
+        ),
+    )
+    with Session(postgres_engine) as session:
+        with pytest.raises(InjectedFailure):
+            PersistenceCoordinator(session).persist_trigger_intent(
+                trigger=value.trigger,
+                intent=value.intent,
+                setup=triggered,
+                setup_transition=transition,
+            )
+    with Session(postgres_engine) as observer:
+        stored = PostgresArmedSetupRepository(observer).get(value.signal.signal_id)
+        assert stored is not None and stored.state is ArmedSetupState.ARMED
+        assert PostgresTriggerEventRepository(observer).get(value.trigger.trigger_event_id) is None
+        assert PostgresEntryIntentRepository(observer).get(value.intent.entry_intent_id) is None
+        assert PostgresStateTransitionRepository(observer).get(transition.transition_id) is None
+
+
+@pytest.mark.parametrize("after", (1, 2))
+def test_coordinator_expiry_boundary_rolls_back_each_write(
+    postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
+) -> None:
+    value = facts(f"sf046-expiry-{after}", at=AT + timedelta(days=20 + after))
+    _commit_armed_setup(postgres_engine, value)
+    expired = replace(value.setup)
+    expired.expire(at=expired.valid_until, reason=ExpiryReason.VALIDITY_WINDOW_END)
+    transition = _transition(
+        value,
+        entity=TransitionEntityType.ARMED_SETUP,
+        entity_id=str(value.signal.signal_id),
+        before="armed",
+        after="expired",
+        cause_type="completed_candle",
+        cause_id="candle",
+        occurred_at=expired.terminal_at or expired.valid_until,
+    )
+    _inject_after(
+        monkeypatch,
+        after=after,
+        names=("PostgresArmedSetupRepository", "PostgresStateTransitionRepository"),
+    )
+    with Session(postgres_engine) as session:
+        with pytest.raises(InjectedFailure):
+            PersistenceCoordinator(session).persist_expiry(
+                run_id=value.run.run_id, setup=expired, setup_transition=transition
+            )
+    with Session(postgres_engine) as observer:
+        stored = PostgresArmedSetupRepository(observer).get(value.signal.signal_id)
+        assert stored is not None and stored.state is ArmedSetupState.ARMED
+        assert PostgresStateTransitionRepository(observer).get(transition.transition_id) is None
+
+
+def _commit_trigger_intent(postgres_engine: Engine, value: Facts) -> None:
+    _commit_armed_setup(postgres_engine, value)
+    triggered = replace(value.setup)
+    triggered.trigger(at=value.trigger.observed_at)
+    with Session(postgres_engine) as session:
+        PostgresTriggerEventRepository(session).append(value.trigger)
+        PostgresEntryIntentRepository(session).append(value.intent)
+        PostgresArmedSetupRepository(session).upsert(value.run.run_id, triggered)
+        session.commit()
+
+
+@pytest.mark.parametrize("after", (1, 2, 3, 4, 5, 6))
+def test_coordinator_opened_entry_boundary_rolls_back_each_write(
+    postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
+) -> None:
+    value = facts(f"sf046-open-v2-{after}", at=AT + timedelta(days=130 + after))
+    _commit_trigger_intent(postgres_engine, value)
+    outcome = PositionOpenOutcome.create(
+        fill_id=value.fill.fill_id, outcome=PositionOpenOutcomeType.OPENED, run=value.run
+    )
+    trade_transition = _transition(
+        value,
+        entity=TransitionEntityType.TRADE,
+        entity_id=str(value.trade.trade_id),
+        before="none",
+        after="open",
+        cause_type="fill",
+        cause_id=str(value.fill.fill_id),
+        occurred_at=value.trade.opened_at,
+    )
+    position_transition = _transition(
+        value,
+        entity=TransitionEntityType.POSITION,
+        entity_id=str(value.position.position_id),
+        before="none",
+        after="open",
+        cause_type="trade",
+        cause_id=str(value.trade.trade_id),
+        occurred_at=value.position.opened_at,
+    )
+    _inject_after(
+        monkeypatch,
+        after=after,
+        names=(
+            "PostgresFillRepository",
+            "PostgresPositionOpenOutcomeRepository",
+            "PostgresTradeRepository",
+            "PostgresPositionRepository",
+            "PostgresStateTransitionRepository",
+            "PostgresStateTransitionRepository",
+        ),
+    )
+    with Session(postgres_engine) as session:
+        with pytest.raises(InjectedFailure):
+            PersistenceCoordinator(session).persist_opened_entry(
+                fill=value.fill,
+                outcome=outcome,
+                trade=value.trade,
+                position=value.position,
+                trade_transition=trade_transition,
+                position_transition=position_transition,
+            )
+    with Session(postgres_engine) as observer:
+        assert PostgresFillRepository(observer).get(value.fill.fill_id) is None
+        assert PostgresPositionOpenOutcomeRepository(observer).get(outcome.outcome_id) is None
+        assert PostgresTradeRepository(observer).get(value.trade.trade_id) is None
+        assert PostgresPositionRepository(observer).get(value.position.position_id) is None
+        assert (
+            PostgresStateTransitionRepository(observer).get(trade_transition.transition_id) is None
+        )
+        assert (
+            PostgresStateTransitionRepository(observer).get(position_transition.transition_id)
+            is None
+        )
+
+
+@pytest.mark.parametrize("after", (1, 2))
+def test_coordinator_rejected_entry_boundary_rolls_back_each_write(
+    postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
+) -> None:
+    value = facts(f"sf046-reject-v2-{after}", at=AT + timedelta(days=140 + after))
+    _commit_trigger_intent(postgres_engine, value)
+    outcome = PositionOpenOutcome.create(
+        fill_id=value.fill.fill_id,
+        outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
+        run=value.run,
+    )
+    _inject_after(
+        monkeypatch,
+        after=after,
+        names=("PostgresFillRepository", "PostgresPositionOpenOutcomeRepository"),
+    )
+    with Session(postgres_engine) as session:
+        with pytest.raises(InjectedFailure):
+            PersistenceCoordinator(session).persist_rejected_entry(fill=value.fill, outcome=outcome)
+    with Session(postgres_engine) as observer:
+        assert PostgresFillRepository(observer).get(value.fill.fill_id) is None
+        assert PostgresPositionOpenOutcomeRepository(observer).get(outcome.outcome_id) is None
+        assert PostgresTradeRepository(observer).get(value.trade.trade_id) is None
+        assert PostgresPositionRepository(observer).get(value.position.position_id) is None
+
+
+def _commit_open_position(postgres_engine: Engine, value: Facts) -> None:
+    _commit_trigger_intent(postgres_engine, value)
+    with Session(postgres_engine) as session:
+        PostgresFillRepository(session).append(value.fill)
+        PostgresTradeRepository(session).upsert(value.trade)
+        PostgresPositionRepository(session).upsert(value.position)
+        session.commit()
+
+
+@pytest.mark.parametrize("after", (1, 2, 3, 4, 5))
+def test_coordinator_exit_boundary_rolls_back_each_write(
+    postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch, after: int
+) -> None:
+    value = facts(f"sf046-exit-v2-{after}", at=AT + timedelta(days=150 + after))
+    _commit_open_position(postgres_engine, value)
+    closed_trade = replace(value.trade)
+    closed_trade.close(exit_id=value.exit_fact.exit_id, at=value.exit_fact.exited_at)
+    closed_position = replace(value.position)
+    closed_position.close(at=value.exit_fact.exited_at)
+    trade_transition = _transition(
+        value,
+        entity=TransitionEntityType.TRADE,
+        entity_id=str(value.trade.trade_id),
+        before="open",
+        after="closed",
+        cause_type="exit",
+        cause_id=str(value.exit_fact.exit_id),
+        occurred_at=value.exit_fact.exited_at,
+    )
+    position_transition = _transition(
+        value,
+        entity=TransitionEntityType.POSITION,
+        entity_id=str(value.position.position_id),
+        before="open",
+        after="closed",
+        cause_type="exit",
+        cause_id=str(value.exit_fact.exit_id),
+        occurred_at=value.exit_fact.exited_at,
+    )
+    _inject_after(
+        monkeypatch,
+        after=after,
+        names=(
+            "PostgresExitRepository",
+            "PostgresTradeRepository",
+            "PostgresPositionRepository",
+            "PostgresStateTransitionRepository",
+            "PostgresStateTransitionRepository",
+        ),
+    )
+    with Session(postgres_engine) as session:
+        with pytest.raises(InjectedFailure):
+            PersistenceCoordinator(session).persist_exit(
+                exit_fact=value.exit_fact,
+                trade=closed_trade,
+                position=closed_position,
+                trade_transition=trade_transition,
+                position_transition=position_transition,
+            )
+    with Session(postgres_engine) as observer:
+        assert PostgresExitRepository(observer).get(value.exit_fact.exit_id) is None
+        trade = PostgresTradeRepository(observer).get(value.trade.trade_id)
+        position = PostgresPositionRepository(observer).get(value.position.position_id)
+        assert trade is not None and trade.state is TradeState.OPEN
+        assert position is not None and position.state is PositionState.OPEN
+        assert (
+            PostgresStateTransitionRepository(observer).get(trade_transition.transition_id) is None
+        )
+        assert (
+            PostgresStateTransitionRepository(observer).get(position_transition.transition_id)
+            is None
+        )
 
 
 def test_all_immutable_repositories_round_trip_and_retry_exactly(session: Session) -> None:

--- a/tests/integration/persistence/test_repository_adapters_postgres.py
+++ b/tests/integration/persistence/test_repository_adapters_postgres.py
@@ -17,6 +17,7 @@ from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, Trigg
 from signalforge.domain.exits import Exit, ExitReason
 from signalforge.domain.ids import ConfigId, FillId, InstrumentId, RunId
 from signalforge.domain.money import Price, Quantity
+from signalforge.domain.position_outcomes import PositionOpenOutcome, PositionOpenOutcomeType
 from signalforge.domain.positions import Position, PositionState
 from signalforge.domain.provenance import RunIdentity, StrategyIdentity
 from signalforge.domain.signals import Signal
@@ -36,6 +37,7 @@ from signalforge.persistence.repositories import (
     PostgresEntryIntentRepository,
     PostgresExitRepository,
     PostgresFillRepository,
+    PostgresPositionOpenOutcomeRepository,
     PostgresPositionRepository,
     PostgresRunProvenanceRepository,
     PostgresSignalRepository,
@@ -441,6 +443,28 @@ def test_authoritative_repositories_apply_forward_transitions_and_terminal_retri
     stored_expired = setups.get(expired.signal_id)
     assert stored_expired is not None
     assert stored_expired.state is ArmedSetupState.EXPIRED
+
+
+def test_position_open_outcome_is_exactly_one_idempotent_fact_per_fill(session: Session) -> None:
+    value = facts("position-open-outcome", at=AT + timedelta(hours=13))
+    persist_graph(session, value)
+    repository = PostgresPositionOpenOutcomeRepository(session)
+    opened = PositionOpenOutcome.create(
+        fill_id=value.fill.fill_id,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=value.run,
+    )
+
+    assert repository.append(opened) == opened
+    assert repository.append(opened) == opened
+
+    rejected = PositionOpenOutcome.create(
+        fill_id=value.fill.fill_id,
+        outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
+        run=value.run,
+    )
+    with pytest.raises(ContradictoryFactError):
+        repository.append(rejected)
 
 
 def test_authoritative_repositories_reject_conflicts_and_keep_outer_transaction_usable(

--- a/tests/unit/domain/test_position_outcomes.py
+++ b/tests/unit/domain/test_position_outcomes.py
@@ -1,6 +1,14 @@
-from signalforge.domain.ids import ConfigId, FillId, RunId
+from datetime import datetime
+
+import pytest
+
+from signalforge.domain.ids import ConfigId, FillId, RunId, SignalId
 from signalforge.domain.position_outcomes import PositionOpenOutcome, PositionOpenOutcomeType
 from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+from signalforge.domain.time import IST
+
+AT = datetime(2026, 9, 2, 10, 0, tzinfo=IST)
+SIGNAL_ID = SignalId("sf046-signal")
 
 
 def _run() -> RunIdentity:
@@ -15,10 +23,18 @@ def _run() -> RunIdentity:
 
 def test_position_open_outcome_is_deterministic_per_run_and_fill() -> None:
     first = PositionOpenOutcome.create(
-        fill_id=FillId("sf046-fill"), outcome=PositionOpenOutcomeType.OPENED, run=_run()
+        fill_id=FillId("sf046-fill"),
+        signal_id=SIGNAL_ID,
+        decided_at=AT,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=_run(),
     )
     second = PositionOpenOutcome.create(
-        fill_id=FillId("sf046-fill"), outcome=PositionOpenOutcomeType.OPENED, run=_run()
+        fill_id=FillId("sf046-fill"),
+        signal_id=SIGNAL_ID,
+        decided_at=AT,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=_run(),
     )
 
     assert first == second
@@ -26,13 +42,30 @@ def test_position_open_outcome_is_deterministic_per_run_and_fill() -> None:
 
 def test_position_open_outcome_identity_is_scoped_to_causal_run_and_fill() -> None:
     opened = PositionOpenOutcome.create(
-        fill_id=FillId("sf046-fill"), outcome=PositionOpenOutcomeType.OPENED, run=_run()
+        fill_id=FillId("sf046-fill"),
+        signal_id=SIGNAL_ID,
+        decided_at=AT,
+        outcome=PositionOpenOutcomeType.OPENED,
+        run=_run(),
     )
     rejected = PositionOpenOutcome.create(
         fill_id=opened.fill_id,
+        signal_id=SignalId("sf046-other-signal"),
+        decided_at=AT.replace(hour=11),
         outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
         run=opened.run,
     )
 
     assert rejected.outcome_id == opened.outcome_id
     assert rejected != opened
+
+
+def test_position_open_outcome_requires_an_aware_decision_timestamp() -> None:
+    with pytest.raises(ValueError):
+        PositionOpenOutcome.create(
+            fill_id=FillId("sf046-fill"),
+            signal_id=SIGNAL_ID,
+            outcome=PositionOpenOutcomeType.OPENED,
+            decided_at=datetime(2026, 9, 2, 10, 0),
+            run=_run(),
+        )

--- a/tests/unit/domain/test_position_outcomes.py
+++ b/tests/unit/domain/test_position_outcomes.py
@@ -1,0 +1,38 @@
+from signalforge.domain.ids import ConfigId, FillId, RunId
+from signalforge.domain.position_outcomes import PositionOpenOutcome, PositionOpenOutcomeType
+from signalforge.domain.provenance import RunIdentity, StrategyIdentity
+
+
+def _run() -> RunIdentity:
+    return RunIdentity(
+        run_id=RunId("sf046-outcome-run"),
+        strategy=StrategyIdentity("intraday_momentum_v1", "1.0.0"),
+        config_id=ConfigId("sf046-outcome-config"),
+        config_hash="sf046-outcome-hash",
+        engine_calculation_version="engine-v1",
+    )
+
+
+def test_position_open_outcome_is_deterministic_per_run_and_fill() -> None:
+    first = PositionOpenOutcome.create(
+        fill_id=FillId("sf046-fill"), outcome=PositionOpenOutcomeType.OPENED, run=_run()
+    )
+    second = PositionOpenOutcome.create(
+        fill_id=FillId("sf046-fill"), outcome=PositionOpenOutcomeType.OPENED, run=_run()
+    )
+
+    assert first == second
+
+
+def test_position_open_outcome_identity_is_scoped_to_causal_run_and_fill() -> None:
+    opened = PositionOpenOutcome.create(
+        fill_id=FillId("sf046-fill"), outcome=PositionOpenOutcomeType.OPENED, run=_run()
+    )
+    rejected = PositionOpenOutcome.create(
+        fill_id=opened.fill_id,
+        outcome=PositionOpenOutcomeType.REJECTED_NON_POSITIVE_RISK,
+        run=opened.run,
+    )
+
+    assert rejected.outcome_id == opened.outcome_id
+    assert rejected != opened

--- a/tests/unit/persistence/test_mappers.py
+++ b/tests/unit/persistence/test_mappers.py
@@ -9,6 +9,7 @@ from signalforge.domain.execution import EntryIntent, ExecutionMode, Fill, Trigg
 from signalforge.domain.exits import Exit, ExitReason
 from signalforge.domain.ids import ConfigId, InstrumentId, RunId
 from signalforge.domain.money import Price, Quantity
+from signalforge.domain.position_outcomes import PositionOpenOutcome, PositionOpenOutcomeType
 from signalforge.domain.positions import Position
 from signalforge.domain.provenance import RunIdentity, StrategyIdentity
 from signalforge.domain.signals import Signal
@@ -31,6 +32,8 @@ from signalforge.persistence.mappers import (
     fill_from_record,
     fill_record_from_domain,
     position_from_record,
+    position_open_outcome_from_record,
+    position_open_outcome_record_from_domain,
     position_record_from_domain,
     run_identity_from_records,
     run_record_from_domain,
@@ -168,6 +171,20 @@ def test_business_fact_and_current_state_mappers_round_trip() -> None:
     fill_record = fill_record_from_domain(fill)
     restored_fill = fill_from_record(fill_record, run)
     assert _record_values(fill_record_from_domain(restored_fill)) == _record_values(fill_record)
+
+    outcome = PositionOpenOutcome.create(
+        fill_id=fill.fill_id,
+        signal_id=fill.signal_id,
+        outcome=PositionOpenOutcomeType.OPENED,
+        decided_at=fill.filled_at,
+        run=run,
+    )
+    outcome_record = position_open_outcome_record_from_domain(outcome)
+    restored_outcome = position_open_outcome_from_record(outcome_record, run)
+    assert restored_outcome.decided_at.tzinfo is not None
+    assert _record_values(position_open_outcome_record_from_domain(restored_outcome)) == (
+        _record_values(outcome_record)
+    )
 
     trade = Trade.open_from_fill(
         entry_fill=fill,


### PR DESCRIPTION
## Summary

Implements SF-046 atomic persistence orchestration and the accepted blocking design completion for durable position-open outcomes.

### Durable position-open outcome

- adds immutable `PositionOpenOutcome`
- accepted values: `OPENED` and `REJECTED_NON_POSITIVE_RISK`
- exactly one logical outcome per Fill
- deterministic identity from accepted Run + Fill causal identity conventions
- adds SQL-free contract, explicit mapper, PostgreSQL adapter, ORM model, and forward-only Alembic migration `20260902_0003`

### Atomic coordinator boundaries

Implements a narrow `PersistenceCoordinator` for the six accepted SF-046 cases:

1. StrategyEvaluation + Signal + ArmedSetup(ARMED) + opening StateTransition
2. ArmedSetup ARMED→EXPIRED + expiry StateTransition
3. TriggerEvent + EntryIntent + ArmedSetup ARMED→TRIGGERED + trigger StateTransition
4A. Fill + PositionOpenOutcome(OPENED) + OPEN Trade + OPEN Position + opening transitions
4B. Fill + PositionOpenOutcome(REJECTED_NON_POSITIVE_RISK)
5. Exit + CLOSED Trade + CLOSED Position + closing transitions

Repositories continue to use caller-provided synchronous SQLAlchemy Sessions and do not own top-level commit/rollback.

## Idempotency and integrity

Coverage proves:

- same-session and fresh-session exact retries for all six coordinator boundaries
- deterministic logical row reuse without duplicate transition/fact creation
- all 23 injected failure points roll back atomically and are verified from a fresh Session
- both OPENED→REJECTED and REJECTED→OPENED PositionOpenOutcome conflicts raise `ContradictoryFactError` while preserving the original durable outcome
- missing Fill dependency raises `PersistenceDependencyError`
- exact compatible Fill-only partial graph can complete safely
- contradictory partial outcome does not create Trade, Position, or opening transitions
- terminal retry/replacement/regression semantics remain aligned with SF-045C

## Migration

Adds forward-only revision `20260902_0003` creating `position_open_outcomes` without rewriting merged SF-044/SF-045 migrations.

Downgrade/re-upgrade coverage includes:

`20260902_0003 → 20260901_0002 → 20260902_0003`

Alembic has exactly one head.

## Validation

- unit persistence: 6 passed
- integration persistence: 41 passed
- unit runtime: 168 passed
- integration runtime: 45 passed
- full `pytest -s`: 431 passed
- Ruff: passed
- mypy: passed
- `git diff --check`: passed
- Alembic: `20260902_0003 (head)`

## Scope discipline

No strategy changes, lifecycle semantic changes, SF-047 checkpoint/recovery implementation, broker/OpenAlgo integration, event sourcing, generic Unit of Work framework, or unrelated schema changes.

Closes #102