### PR TITLE
SF-048 — M6 PostgreSQL persistence and idempotency integration tests

### DIFF
--- a/tests/integration/persistence/test_m6_persistence_golden.py
+++ b/tests/integration/persistence/test_m6_persistence_golden.py
@@ -1,0 +1,196 @@
+import os
+from collections.abc import Iterator
+from dataclasses import replace
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from signalforge.domain.armed import ArmedSetupState
+from signalforge.domain.audit import TransitionEntityType
+from signalforge.domain.position_outcomes import PositionOpenOutcome, PositionOpenOutcomeType
+from signalforge.domain.positions import PositionState
+from signalforge.domain.trades import TradeState
+from signalforge.persistence.coordinator import PersistenceCoordinator
+from signalforge.persistence.repositories import (
+    PostgresArmedSetupRepository,
+    PostgresEntryIntentRepository,
+    PostgresExitRepository,
+    PostgresFillRepository,
+    PostgresIndicatorCheckpointRepository,
+    PostgresPositionOpenOutcomeRepository,
+    PostgresPositionRepository,
+    PostgresRunProvenanceRepository,
+    PostgresSignalRepository,
+    PostgresStateTransitionRepository,
+    PostgresStrategyEvaluationRepository,
+    PostgresTradeRepository,
+    PostgresTriggerEventRepository,
+)
+from signalforge.runtime.indicators import IndicatorEngine
+from tests.integration.persistence.test_repository_adapters_postgres import (
+    _transition,
+    facts,
+)
+
+
+@pytest.fixture(scope="module")
+def postgres_engine() -> Iterator[Engine]:
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url is None:
+        pytest.fail("DATABASE_URL is required for PostgreSQL integration tests")
+    engine = sa.create_engine(database_url)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def test_m6_complete_lifecycle_is_durable_and_idempotent(postgres_engine: Engine) -> None:
+    value = facts(f"m6-{uuid4().hex[:8]}")
+    checkpoint = IndicatorEngine(value.signal.instrument_id, "checkpoint-v1").state
+    arm = _transition(
+        value,
+        entity=TransitionEntityType.ARMED_SETUP,
+        entity_id=str(value.signal.signal_id),
+        before="none",
+        after="armed",
+        cause_type="strategy_evaluation",
+        cause_id="evaluation",
+        occurred_at=value.setup.armed_at,
+    )
+    setup = replace(value.setup)
+    setup.trigger(at=value.trigger.observed_at)
+    trigger = _transition(
+        value,
+        entity=TransitionEntityType.ARMED_SETUP,
+        entity_id=str(value.signal.signal_id),
+        before="armed",
+        after="triggered",
+        cause_type="trigger_event",
+        cause_id=str(value.trigger.trigger_event_id),
+        occurred_at=value.trigger.observed_at,
+    )
+    outcome = PositionOpenOutcome.create(
+        fill_id=value.fill.fill_id,
+        signal_id=value.signal.signal_id,
+        outcome=PositionOpenOutcomeType.OPENED,
+        decided_at=value.fill.filled_at,
+        run=value.run,
+    )
+    trade_open = _transition(
+        value,
+        entity=TransitionEntityType.TRADE,
+        entity_id=str(value.trade.trade_id),
+        before="none",
+        after="open",
+        cause_type="fill",
+        cause_id=str(value.fill.fill_id),
+        occurred_at=value.trade.opened_at,
+    )
+    position_open = _transition(
+        value,
+        entity=TransitionEntityType.POSITION,
+        entity_id=str(value.position.position_id),
+        before="none",
+        after="open",
+        cause_type="trade",
+        cause_id=str(value.trade.trade_id),
+        occurred_at=value.position.opened_at,
+    )
+    trade = replace(value.trade)
+    trade.close(exit_id=value.exit_fact.exit_id, at=value.exit_fact.exited_at)
+    position = replace(value.position)
+    position.close(at=value.exit_fact.exited_at)
+    trade_close = _transition(
+        value,
+        entity=TransitionEntityType.TRADE,
+        entity_id=str(value.trade.trade_id),
+        before="open",
+        after="closed",
+        cause_type="exit",
+        cause_id=str(value.exit_fact.exit_id),
+        occurred_at=value.exit_fact.exited_at,
+    )
+    position_close = _transition(
+        value,
+        entity=TransitionEntityType.POSITION,
+        entity_id=str(value.position.position_id),
+        before="open",
+        after="closed",
+        cause_type="exit",
+        cause_id=str(value.exit_fact.exit_id),
+        occurred_at=value.exit_fact.exited_at,
+    )
+    with Session(postgres_engine) as session:
+        PostgresRunProvenanceRepository(session).add(value.run)
+        session.commit()
+        coordinator = PersistenceCoordinator(session)
+        coordinator.persist_actionable_evaluation(
+            evaluation=value.evaluation,
+            signal=value.signal,
+            setup=value.setup,
+            setup_transition=arm,
+            checkpoint=checkpoint,
+        )
+        coordinator.persist_trigger_intent(
+            trigger=value.trigger, intent=value.intent, setup=setup, setup_transition=trigger
+        )
+        coordinator.persist_opened_entry(
+            fill=value.fill,
+            outcome=outcome,
+            trade=value.trade,
+            position=value.position,
+            trade_transition=trade_open,
+            position_transition=position_open,
+        )
+        coordinator.persist_exit(
+            exit_fact=value.exit_fact,
+            trade=trade,
+            position=position,
+            trade_transition=trade_close,
+            position_transition=position_close,
+        )
+    with Session(postgres_engine) as observer:
+        assert PostgresRunProvenanceRepository(observer).get(value.run.run_id) == value.run
+        assert (
+            PostgresStrategyEvaluationRepository(observer).get(
+                value.run.run_id, value.evaluation.instrument_id, value.evaluation.interval
+            )
+            == value.evaluation
+        )
+        assert PostgresSignalRepository(observer).get(value.signal.signal_id) == value.signal
+        assert (
+            PostgresArmedSetupRepository(observer).get(value.signal.signal_id).state
+            is ArmedSetupState.TRIGGERED
+        )
+        assert (
+            PostgresTriggerEventRepository(observer).get(value.trigger.trigger_event_id)
+            == value.trigger
+        )
+        assert (
+            PostgresEntryIntentRepository(observer).get(value.intent.entry_intent_id)
+            == value.intent
+        )
+        assert PostgresFillRepository(observer).get(value.fill.fill_id) == value.fill
+        assert PostgresPositionOpenOutcomeRepository(observer).get(outcome.outcome_id) == outcome
+        assert (
+            PostgresTradeRepository(observer).get(value.trade.trade_id).state is TradeState.CLOSED
+        )
+        assert (
+            PostgresPositionRepository(observer).get(value.position.position_id).state
+            is PositionState.CLOSED
+        )
+        assert PostgresExitRepository(observer).get(value.exit_fact.exit_id) == value.exit_fact
+        assert (
+            PostgresIndicatorCheckpointRepository(observer).get(
+                value.run.run_id, value.signal.instrument_id
+            )
+            == checkpoint
+        )
+        assert all(
+            PostgresStateTransitionRepository(observer).get(item.transition_id) == item
+            for item in (arm, trigger, trade_open, position_open, trade_close, position_close)
+        )

--- a/tests/integration/persistence/test_m6_persistence_golden.py
+++ b/tests/integration/persistence/test_m6_persistence_golden.py
@@ -135,6 +135,16 @@ def test_m6_complete_lifecycle_is_durable_and_idempotent(postgres_engine: Engine
             setup_transition=arm,
             checkpoint=checkpoint,
         )
+        coordinator.persist_actionable_evaluation(
+            evaluation=value.evaluation,
+            signal=value.signal,
+            setup=value.setup,
+            setup_transition=arm,
+            checkpoint=checkpoint,
+        )
+        coordinator.persist_trigger_intent(
+            trigger=value.trigger, intent=value.intent, setup=setup, setup_transition=trigger
+        )
         coordinator.persist_trigger_intent(
             trigger=value.trigger, intent=value.intent, setup=setup, setup_transition=trigger
         )
@@ -145,6 +155,21 @@ def test_m6_complete_lifecycle_is_durable_and_idempotent(postgres_engine: Engine
             position=value.position,
             trade_transition=trade_open,
             position_transition=position_open,
+        )
+        coordinator.persist_opened_entry(
+            fill=value.fill,
+            outcome=outcome,
+            trade=value.trade,
+            position=value.position,
+            trade_transition=trade_open,
+            position_transition=position_open,
+        )
+        coordinator.persist_exit(
+            exit_fact=value.exit_fact,
+            trade=trade,
+            position=position,
+            trade_transition=trade_close,
+            position_transition=position_close,
         )
         coordinator.persist_exit(
             exit_fact=value.exit_fact,

--- a/tests/integration/persistence/test_m6_persistence_golden.py
+++ b/tests/integration/persistence/test_m6_persistence_golden.py
@@ -1,13 +1,17 @@
 import os
+import sys
 from collections.abc import Iterator
 from dataclasses import replace
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 import sqlalchemy as sa
+from alembic.config import Config
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
+from alembic import command
 from signalforge.domain.armed import ArmedSetupState
 from signalforge.domain.audit import TransitionEntityType
 from signalforge.domain.position_outcomes import PositionOpenOutcome, PositionOpenOutcomeType
@@ -30,6 +34,7 @@ from signalforge.persistence.repositories import (
     PostgresTriggerEventRepository,
 )
 from signalforge.runtime.indicators import IndicatorEngine
+from tests.integration.persistence.test_migrations import EXPECTED_TABLES
 from tests.integration.persistence.test_repository_adapters_postgres import (
     _transition,
     facts,
@@ -219,3 +224,29 @@ def test_m6_complete_lifecycle_is_durable_and_idempotent(postgres_engine: Engine
             PostgresStateTransitionRepository(observer).get(item.transition_id) == item
             for item in (arm, trigger, trade_open, position_open, trade_close, position_close)
         )
+
+
+def test_m6_fresh_database_reproducibility(
+    postgres_engine: Engine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = Config("alembic.ini")
+
+    def run_clean() -> dict[str, tuple[str, ...]]:
+        command.downgrade(config, "base")
+        command.upgrade(config, "head")
+        monkeypatch.setattr(
+            sys.modules[__name__],
+            "uuid4",
+            lambda: SimpleNamespace(hex="m6repro000000000000000000000000"),
+        )
+        test_m6_complete_lifecycle_is_durable_and_idempotent(postgres_engine)
+        with postgres_engine.connect() as connection:
+            projection = {}
+            for table in sorted(EXPECTED_TABLES):
+                rows = connection.execute(sa.text(f"SELECT * FROM {table}")).mappings().all()
+                projection[table] = tuple(sorted(repr(dict(row)) for row in rows))
+            return projection
+
+    first = run_clean()
+    second = run_clean()
+    assert second == first


### PR DESCRIPTION
## Summary

Completes SF-048, the M6 PostgreSQL persistence/idempotency golden validation layer.

### Coverage

- durable end-to-end lifecycle persisted and reloaded from a fresh PostgreSQL Session
- exact indicator checkpoint round-trip
- integrated exact-retry/idempotency coverage
- lifecycle/current-state and transition consistency
- Decimal/timestamp semantic round-trip checks
- clean-database reproducibility: deterministic logical projection matches across independently reset/migrated runs
- existing representative SF-046/SF-047 rollback coverage remains green
- no production-code changes

### Validation

- persistence integration: 56 passed
- full suite: 447 passed
- Ruff: passed
- mypy: passed
- git diff --check: passed
- Alembic: 20260902_0004 (head), exactly one head

No M7 recovery behavior, broker work, strategy changes, indicator changes, or new persistence architecture is included.

Closes #104